### PR TITLE
Tests - Action to build Refman doc

### DIFF
--- a/.github/workflows/build-doc-refman.yml
+++ b/.github/workflows/build-doc-refman.yml
@@ -1,0 +1,36 @@
+# This workflow will build OCCT refman documentation.
+
+name: Build Refman Documentation
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4.2.1
+
+    - name: Install dependencies
+      run: sudo apt-get update && sudo apt-get install -y tcl-dev tk-dev cmake gcc g++ make libbtbb-dev libx11-dev libglu1-mesa-dev doxygen graphviz
+
+    - name: Build documentation
+      run: bash gendoc -refman
+
+    - name: Upload refman documentation
+      uses: actions/upload-artifact@v4.4.3
+      id: artifact-upload-step
+      with:
+        name: refman-doc
+        path: doc/refman
+        retention-days: 90
+
+    - name: Upload generation log
+      uses: actions/upload-artifact@v4.4.3
+      with:
+        name: dogygen.log
+        path: doc/html_doxygen_err.log


### PR DESCRIPTION
Add GitHub Actions workflow for building OCCT refman documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an automated workflow for building and publishing OCCT reference manual documentation.
	- Documentation is generated and stored automatically on pull requests and pushes to the master branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->