### PR TITLE
Coding - Fixing clang-tidy warnings

### DIFF
--- a/src/Adaptor3d/Adaptor3d_CurveOnSurface.cxx
+++ b/src/Adaptor3d/Adaptor3d_CurveOnSurface.cxx
@@ -219,8 +219,7 @@ static void FindBounds(const TColStd_Array1OfReal& Arr,
   if((N!=Bound1)&&(N!=Bound2))  { 
     if(Abs(Der) > Tol ) { 
       if(Der>0) {Bound1=N;Bound2= N+1;}
-      else
-      if(Der<0){Bound1=N-1;Bound2=N;}
+      else {Bound1=N-1;Bound2=N;}
       DerNull = Standard_False;
     }
     if(Abs(Der) <=Tol ) {

--- a/src/AdvApp2Var/AdvApp2Var_ApproxF2var.cxx
+++ b/src/AdvApp2Var/AdvApp2Var_ApproxF2var.cxx
@@ -5917,7 +5917,6 @@ int mma2er2_(integer *ndjacu,
   integer i2rdu, i2rdv;
   doublereal errnu, errnv;
   integer ii, nd, jj, nu, nv;
-  doublereal bid0, bid1;
 
 /* ********************************************************************** 
 */
@@ -6031,12 +6030,11 @@ L1001:
 /* ---------------- by U, the degree by V is fixed to NV ----------------- 
 */
 
-    bid0 = 0.;
     if (nv > *mindgv) {
-	bid0 = xmaxjv[nv - i2rdv];
+	doublereal bid0 = xmaxjv[nv - i2rdv];
 	i__1 = *ndimen;
 	for (nd = 1; nd <= i__1; ++nd) {
-	    bid1 = 0.;
+	    doublereal bid1 = 0.;
 	    i__2 = nu;
 	    for (ii = i2rdu; ii <= i__2; ++ii) {
 		bid1 += (d__1 = patjac[ii + (nv + nd * patjac_dim2) * 
@@ -6056,12 +6054,11 @@ L1001:
 /* ---------------- by V, the degree by U is fixed to NU ----------------- 
 */
 
-    bid0 = 0.;
     if (nu > *mindgu) {
-	bid0 = xmaxju[nu - i2rdu];
+	doublereal bid0 = xmaxju[nu - i2rdu];
 	i__1 = *ndimen;
 	for (nd = 1; nd <= i__1; ++nd) {
-	    bid1 = 0.;
+	    doublereal bid1 = 0.;
 	    i__2 = nv;
 	    for (jj = i2rdv; jj <= i__2; ++jj) {
 		bid1 += (d__1 = patjac[nu + (jj + nd * patjac_dim2) * 

--- a/src/AdvApprox/AdvApprox_ApproxAFunction.cxx
+++ b/src/AdvApprox/AdvApprox_ApproxAFunction.cxx
@@ -419,7 +419,7 @@ void AdvApprox_ApproxAFunction::Approximation(
 					      Standard_Integer& ErrorCode)
 {
 //  Standard_Real EpsPar =  Precision::Confusion();
-  Standard_Integer IDIM, NUPIL,TheDeg;
+  Standard_Integer NUPIL,TheDeg;
 #ifdef OCCT_DEBUG
   Standard_Integer NDIMEN = TotalDimension;
 #endif
@@ -440,7 +440,7 @@ void AdvApprox_ApproxAFunction::Approximation(
 
 //--> La dimension totale doit etre la somme des dimensions des
 //    sous-espaces
-      IDIM=0;
+      Standard_Integer IDIM=0;
       for ( Standard_Integer I=1; I<=TotalNumSS; I++) {IDIM += LocalDimension(I);}
       if (IDIM != TotalDimension) 
 	{ErrorCode=1;
@@ -510,7 +510,6 @@ void AdvApprox_ApproxAFunction::Approximation(
 
 //---------- Calcul du degre de la courbe et de l' erreur max ----------
 
-      IDIM=0;
       NumCoeffPerCurveArray(NumCurves + 1)=0;
 
 //    L'erreur doit etre satisfaite sur tous les sous-espaces sinon, on decoupe

--- a/src/AppDef/AppDef_LinearCriteria.cxx
+++ b/src/AppDef/AppDef_LinearCriteria.cxx
@@ -753,13 +753,12 @@ void AppDef_LinearCriteria::BuildCache(const Standard_Integer Element)
 {
   Standard_Real t; 
   Standard_Real UFirst, ULast;
-  Standard_Integer ipnt;
 
   UFirst = myCurve->Knots()(Element); 
   ULast =  myCurve->Knots()(Element + 1);
  
   IF = 0;
-  for(ipnt = myParameters->Lower(); ipnt <= myParameters->Upper(); ipnt++) {
+  for(Standard_Integer ipnt = myParameters->Lower(); ipnt <= myParameters->Upper(); ipnt++) {
     t = myParameters->Value(ipnt); 
     if((t > UFirst && t <= ULast) || (Element == 1 && t == UFirst)) {
       if (IF == 0) IF=ipnt;
@@ -770,11 +769,10 @@ void AppDef_LinearCriteria::BuildCache(const Standard_Integer Element)
 
   if (IF != 0) {
     Handle(PLib_Base) myBase = myCurve->Base();
-    Standard_Integer order = myBase->WorkDegree()+1, ii; 
+    Standard_Integer order = myBase->WorkDegree()+1; 
     myCache = new TColStd_HArray1OfReal (1, (IL-IF+1)*(order));
-    
-    ii =1;
-    for(ipnt = IF, ii=1; ipnt <= IL; ipnt++, ii+=order) {
+
+    for(Standard_Integer ipnt = IF, ii=1; ipnt <= IL; ipnt++, ii+=order) {
       Standard_Real * cache = &myCache->ChangeValue(ii);
       TColStd_Array1OfReal BasicValue(cache[0], 0, order-1);
       t = myParameters->Value(ipnt);

--- a/src/AppDef/AppDef_Variational.cxx
+++ b/src/AppDef/AppDef_Variational.cxx
@@ -459,7 +459,7 @@ void AppDef_Variational::Approximate()
 
   //---------------------------------------------------------------------
 
-  Standard_Integer jp2d,jp3d,index,ipole, 
+  Standard_Integer jp2d,jp3d,ipole, 
     NbElem = TheCurve->NbElements();
 
   TColgp_Array1OfPnt TabP3d(1, Max(1,myNbP3d));
@@ -468,9 +468,6 @@ void AppDef_Variational::Approximate()
 
   gp_Pnt2d P2d;
   gp_Pnt P3d;
-
-  index=0;
-
   {
     Handle(TColStd_HArray2OfReal) PolynomialIntervalsPtr =
       new TColStd_HArray2OfReal(1,NbElem,1,2) ;
@@ -549,7 +546,7 @@ void AppDef_Variational::Approximate()
 
       for (ipole=PolesPtr->LowerRow();ipole<=PolesPtr->UpperRow();ipole++)
       {
-        index=PolesPtr->LowerCol();
+        Standard_Integer index = PolesPtr->LowerCol();
         /*	    if(myNbP2d !=0 ) 
         {
         for (jp2d=1;jp2d<=myNbP2d;jp2d++)
@@ -1150,7 +1147,7 @@ void AppDef_Variational::TheMotor(
 
   Handle(TColStd_HArray1OfReal) CurrentTi, NewTi, OldTi;  
   Handle(TColStd_HArray2OfInteger) Dependence;
-  Standard_Boolean lestim, lconst, ToOptim, iscut;
+  Standard_Boolean lestim, ToOptim, iscut;
   Standard_Boolean isnear = Standard_False, again = Standard_True; 
   Standard_Integer NbEst, ICDANA, NumPnt, Iter;
   Standard_Integer MaxNbEst =5; 
@@ -1198,7 +1195,7 @@ void AppDef_Variational::TheMotor(
 
     // (1) Loop  Optimization / Estimation
     lestim = Standard_True;
-    lconst = Standard_True;
+    Standard_Boolean lconst = Standard_True;
     NbEst = 0;
 
     J->SetCurve(CCurrent);

--- a/src/BSplCLib/BSplCLib.cxx
+++ b/src/BSplCLib/BSplCLib.cxx
@@ -2913,8 +2913,6 @@ BSplCLib::SolveBandedSystem(const math_Matrix&  Matrix,
     if ( Abs(divizor) > Toler )
       Inverse = 1.0e0 / divizor ;
     else {
-      Inverse = 1.0e0;
-//      std::cout << "  BSplCLib::SolveBandedSystem() : zero determinant " << std::endl;
       ReturnCode = 1;
       goto FINISH;
     }

--- a/src/BSplCLib/BSplCLib_BzSyntaxes.cxx
+++ b/src/BSplCLib/BSplCLib_BzSyntaxes.cxx
@@ -27,26 +27,25 @@
 //         knots for bezier (using stack allocation)
 //=======================================================================
 
-class BSplCLib_BezierArrays 
+class BSplCLib_BezierArrays
 {
- public:
-  BSplCLib_BezierArrays (Standard_Integer Degree) 
-  : knots (aKnots[0], 1, 2), mults (aMults[0], 1, 2) 
-  {
-    aKnots[0] = 0.;
-    aKnots[1] = 1.;
-    aMults[0] = aMults[1] = Degree + 1;
-  }
+public:
+  BSplCLib_BezierArrays(Standard_Integer Degree)
+  : aKnots{0., 1.},
+    aMults{Degree + 1, Degree + 1},
+    knots(aKnots[0], 1, 2),
+    mults(aMults[0], 1, 2)
+  {}
 
- private:
-  Standard_Real aKnots[2];
+private:
+  Standard_Real    aKnots[2];
   Standard_Integer aMults[2];
-  
- public:
+
+public:
   TColStd_Array1OfReal    knots;
   TColStd_Array1OfInteger mults;
 };
-  
+
 //=======================================================================
 //function : IncreaseDegree
 //purpose  : 

--- a/src/BndLib/BndLib_Add2dCurve.cxx
+++ b/src/BndLib/BndLib_Add2dCurve.cxx
@@ -62,6 +62,7 @@ class BndLib_Box2dCurve  {
 
   void PerformOptimal(const Standard_Real Tol);
 
+  // Keep myT1 and myT2 unchanged
   void Clear();
 
   Standard_Integer ErrorStatus() const;

--- a/src/Convert/Convert_ConicToBSplineCurve.cxx
+++ b/src/Convert/Convert_ConicToBSplineCurve.cxx
@@ -629,8 +629,7 @@ void Convert_ConicToBSplineCurve::BuildCosAndSin(
   temp_degree,
   pivot_index_problem,
   num_flat_knots,
-  num_knots,
-  order ;
+  num_knots;
 
   if (Parameterisation != Convert_TgtThetaOver2 &&
       Parameterisation != Convert_RationalC1) {
@@ -682,10 +681,9 @@ void Convert_ConicToBSplineCurve::BuildCosAndSin(
 
 
      Degree = 4 ;
-     order = Degree + 1 ;
      num_knots = 5 ;
      num_flat_knots = (Degree -1) * num_knots + 2 * 2 ;
-     num_poles = num_flat_knots - order ;
+     num_poles = num_flat_knots - Degree - 1 ;
      num_periodic_poles = num_poles - 2 ;
      TColStd_Array1OfReal  flat_knots(1,num_flat_knots) ;
      CosNumeratorPtr = 
@@ -721,7 +719,6 @@ void Convert_ConicToBSplineCurve::BuildCosAndSin(
        KnotsPtr->SetValue(ii, (ii-1) * half_pi) ;
        MultsPtr->SetValue(ii, Degree-1) ;
      }
-     order = degree + 1 ;
 
      TColStd_Array1OfReal      parameters(1,num_poles)  ;
      TColgp_Array1OfPnt        poles_array(1,num_poles) ;

--- a/src/Extrema/Extrema_ExtPElS.cxx
+++ b/src/Extrema/Extrema_ExtPElS.cxx
@@ -176,16 +176,15 @@ void Extrema_ExtPElS::Perform(const gp_Pnt&       P,
   gp_Pnt Pp = P.Translated(OZ.Multiplied(-Zp));
   gp_Vec OPp(O, Pp);
   if (OPp.SquareMagnitude() < Tol * Tol) return;
-  Standard_Real B, U1, V1, U2, V2;
+  Standard_Real U1, V1, U2, V2;
   Standard_Boolean Same = DirZ.Dot(MP) >= 0.0;
   U1 = gp_Vec(Pos.XDirection()).AngleWithRef(OPp,myZ); //-M_PI<U1<M_PI
   if (U1 > -ExtPElS_MyEps && U1 < ExtPElS_MyEps) { U1 = 0.; }
-  B = MP.Angle(DirZ);
   if (!Same) { U1 += M_PI; }
   U2 = U1 + M_PI;
   if (U1 < 0.) { U1 += 2. * M_PI; }
   if (U2 > 2.*M_PI) { U2 -= 2. * M_PI; }
-  B = MP.Angle(DirZ);
+  Standard_Real B = MP.Angle(DirZ);
   A = Abs(A);
   Standard_Real L = sqrt(L2);
   if (!Same) {

--- a/src/Extrema/Extrema_GenExtPS.cxx
+++ b/src/Extrema/Extrema_GenExtPS.cxx
@@ -518,8 +518,6 @@ const Extrema_POnSurfParams& Extrema_GenExtPS::ComputeEdgeParameters
 
 void Extrema_GenExtPS::BuildGrid(const gp_Pnt &thePoint)
 {
-  Standard_Integer NoU, NoV;
-
   //if grid was already built skip its creation
   if (!myInit) {
     //build parametric grid in case of a complex surface geometry (BSpline and Bezier surfaces)
@@ -534,7 +532,7 @@ void Extrema_GenExtPS::BuildGrid(const gp_Pnt &thePoint)
       U0 = U0/2. + myumin;
       myUParams = new TColStd_HArray1OfReal(1,myusample );
       Standard_Real U = U0;
-      for ( NoU = 1 ; NoU <= myusample; NoU++, U += PasU) 
+      for (Standard_Integer NoU = 1; NoU <= myusample; NoU++, U += PasU)
         myUParams->SetValue(NoU, U);
     }
   
@@ -547,8 +545,7 @@ void Extrema_GenExtPS::BuildGrid(const gp_Pnt &thePoint)
       
       myVParams = new TColStd_HArray1OfReal(1,myvsample );
       Standard_Real V = V0;
-     
-      for ( NoV = 1, V = V0; NoV <= myvsample; NoV++, V += PasV)
+      for (Standard_Integer NoV = 1; NoV <= myvsample; NoV++, V += PasV)
         myVParams->SetValue(NoV, V);
     }
 
@@ -556,8 +553,8 @@ void Extrema_GenExtPS::BuildGrid(const gp_Pnt &thePoint)
     myPoints.Resize (0, myusample + 1, 0, myvsample + 1, false);
     // Calculation of distances
   
-    for ( NoU = 1 ; NoU <= myusample; NoU++ ) {
-      for ( NoV = 1 ; NoV <= myvsample; NoV++) {
+    for (Standard_Integer NoU = 1 ; NoU <= myusample; NoU++ ) {
+      for (Standard_Integer NoV = 1 ; NoV <= myvsample; NoV++) {
         gp_Pnt aP1 = myS->Value(myUParams->Value(NoU), myVParams->Value(NoV));
         Extrema_POnSurfParams aParam
           (myUParams->Value(NoU), myVParams->Value(NoV), aP1);
@@ -574,12 +571,12 @@ void Extrema_GenExtPS::BuildGrid(const gp_Pnt &thePoint)
 
     // Fill boundary with negative square distance.
     // It is used for computation of Maximum.
-    for (NoV = 0; NoV <= myvsample + 1; NoV++) {
+    for (Standard_Integer NoV = 0; NoV <= myvsample + 1; NoV++) {
       myPoints.ChangeValue(0, NoV).SetSqrDistance(-1.);
       myPoints.ChangeValue(myusample + 1, NoV).SetSqrDistance(-1.);
     }
 
-    for (NoU = 1; NoU <= myusample; NoU++) {
+    for (Standard_Integer NoU = 1; NoU <= myusample; NoU++) {
       myPoints.ChangeValue(NoU, 0).SetSqrDistance(-1.);
       myPoints.ChangeValue(NoU, myvsample + 1).SetSqrDistance(-1.);
     }
@@ -589,8 +586,8 @@ void Extrema_GenExtPS::BuildGrid(const gp_Pnt &thePoint)
 
   // Compute distances to mesh.
   // Step 1. Compute distances to nodes.
-  for ( NoU = 1 ; NoU <= myusample; NoU++ ) {
-    for ( NoV = 1 ; NoV <= myvsample; NoV++) {
+  for (Standard_Integer NoU = 1 ; NoU <= myusample; NoU++ ) {
+    for (Standard_Integer NoV = 1 ; NoV <= myvsample; NoV++) {
       Extrema_POnSurfParams &aParam = myPoints.ChangeValue(NoU, NoV);
 
       aParam.SetSqrDistance(thePoint.SquareDistance(aParam.Value()));
@@ -607,9 +604,9 @@ void Extrema_GenExtPS::BuildGrid(const gp_Pnt &thePoint)
     // Step 2. Compute distances to edges.
     // Assume UEdge(i, j) = { Point(i, j); Point(i + 1, j    ) }
     // Assume VEdge(i, j) = { Point(i, j); Point(i,     j + 1) }
-    for ( NoU = 1 ; NoU <= myusample; NoU++ ) 
+    for (Standard_Integer NoU = 1 ; NoU <= myusample; NoU++ )
     {
-      for ( NoV = 1 ; NoV <= myvsample; NoV++)
+      for (Standard_Integer NoV = 1 ; NoV <= myvsample; NoV++)
       {
         const Extrema_POnSurfParams &aParam0 = myPoints.Value(NoU, NoV);
 
@@ -642,8 +639,8 @@ void Extrema_GenExtPS::BuildGrid(const gp_Pnt &thePoint)
     Standard_Real aDiffDist;
     Standard_Boolean isOut;
 
-    for ( NoU = 1 ; NoU < myusample; NoU++ ) {
-      for ( NoV = 1 ; NoV < myvsample; NoV++) {
+    for (Standard_Integer NoU = 1 ; NoU < myusample; NoU++ ) {
+      for (Standard_Integer NoV = 1 ; NoV < myvsample; NoV++) {
         const Extrema_POnSurfParams &aUE0 = myUEdgePntParams.Value(NoU, NoV);
         const Extrema_POnSurfParams &aUE1 = myUEdgePntParams.Value(NoU, NoV+1);
         const Extrema_POnSurfParams &aVE0 = myVEdgePntParams.Value(NoU, NoV);
@@ -703,12 +700,12 @@ void Extrema_GenExtPS::BuildGrid(const gp_Pnt &thePoint)
     }
 
     // Fill boundary with RealLast square distance.
-    for (NoV = 0; NoV <= myvsample; NoV++) {
+    for (Standard_Integer NoV = 0; NoV <= myvsample; NoV++) {
       myFacePntParams.ChangeValue(0, NoV).SetSqrDistance(RealLast());
       myFacePntParams.ChangeValue(myusample, NoV).SetSqrDistance(RealLast());
     }
 
-    for (NoU = 1; NoU < myusample; NoU++) {
+    for (Standard_Integer NoU = 1; NoU < myusample; NoU++) {
       myFacePntParams.ChangeValue(NoU, 0).SetSqrDistance(RealLast());
       myFacePntParams.ChangeValue(NoU, myvsample).SetSqrDistance(RealLast());
     }
@@ -840,7 +837,7 @@ void Extrema_GenExtPS::BuildTree()
   Standard_Real U = U0, V = V0;
   for ( NoU = 1 ; NoU <= myusample; NoU++, U += PasU) 
     myUParams->SetValue(NoU, U);
-  for ( NoV = 1, V = V0; NoV <= myvsample; NoV++, V += PasV)
+  for ( NoV = 1 ; NoV <= myvsample; NoV++, V += PasV)
     myVParams->SetValue(NoV, V);
 
   // Calculation of distances

--- a/src/FSD/FSD_BinaryFile.cxx
+++ b/src/FSD/FSD_BinaryFile.cxx
@@ -973,7 +973,7 @@ Storage_Error FSD_BinaryFile::EndWriteTypeSection()
 Storage_Error FSD_BinaryFile::BeginReadTypeSection() 
 {
  if (!fseek(myStream,myHeader.btype,SEEK_SET)) return Storage_VSOk;
-  else return Storage_VSSectionNotFound;
+ else return Storage_VSSectionNotFound;
 }
 
 //=======================================================================
@@ -1030,7 +1030,7 @@ void FSD_BinaryFile::ReadTypeInformations(Standard_IStream& theIStream, Standard
 
 Storage_Error FSD_BinaryFile::EndReadTypeSection() 
 {
- if (!fseek(myStream,myHeader.etype,SEEK_SET)) return Storage_VSOk;
+  if (!fseek(myStream,myHeader.etype,SEEK_SET)) return Storage_VSOk;
   else return Storage_VSSectionNotFound;
 }
 
@@ -1085,7 +1085,7 @@ Storage_Error FSD_BinaryFile::EndWriteRootSection()
 
 Storage_Error FSD_BinaryFile::BeginReadRootSection() 
 {
- if (!fseek(myStream,myHeader.broot,SEEK_SET)) return Storage_VSOk;
+  if (!fseek(myStream,myHeader.broot,SEEK_SET)) return Storage_VSOk;
   else return Storage_VSSectionNotFound;
 }
 
@@ -1145,7 +1145,7 @@ void FSD_BinaryFile::ReadRoot (Standard_IStream& theIStream, TCollection_AsciiSt
 
 Storage_Error FSD_BinaryFile::EndReadRootSection() 
 {
- if (!fseek(myStream,myHeader.eroot,SEEK_SET)) return Storage_VSOk;
+  if (!fseek(myStream,myHeader.eroot,SEEK_SET)) return Storage_VSOk;
   else return Storage_VSSectionNotFound;
 }
 
@@ -1199,7 +1199,7 @@ Storage_Error FSD_BinaryFile::EndWriteRefSection()
 
 Storage_Error FSD_BinaryFile::BeginReadRefSection() 
 {
- if (!fseek(myStream,myHeader.bref,SEEK_SET)) return Storage_VSOk;
+  if (!fseek(myStream,myHeader.bref,SEEK_SET)) return Storage_VSOk;
   else return Storage_VSSectionNotFound;
 }
 
@@ -1258,7 +1258,7 @@ void FSD_BinaryFile::ReadReferenceType (Standard_IStream& theIStream, Standard_I
 
 Storage_Error FSD_BinaryFile::EndReadRefSection() 
 {
- if (!fseek(myStream,myHeader.eref,SEEK_SET)) return Storage_VSOk;
+  if (!fseek(myStream,myHeader.eref,SEEK_SET)) return Storage_VSOk;
   else return Storage_VSSectionNotFound;
 }
 
@@ -1342,7 +1342,7 @@ Storage_Error FSD_BinaryFile::EndWriteDataSection()
 
 Storage_Error FSD_BinaryFile::BeginReadDataSection() 
 {
- if (!fseek(myStream,myHeader.bdata,SEEK_SET)) return Storage_VSOk;
+  if (!fseek(myStream,myHeader.bdata,SEEK_SET)) return Storage_VSOk;
   else return Storage_VSSectionNotFound;
 }
 
@@ -1401,7 +1401,7 @@ void FSD_BinaryFile::EndReadPersistentObjectData()
 
 Storage_Error FSD_BinaryFile::EndReadDataSection() 
 {
- if (!fseek(myStream,myHeader.edata,SEEK_SET)) return Storage_VSOk;
+  if (!fseek(myStream,myHeader.edata,SEEK_SET)) return Storage_VSOk;
   else return Storage_VSSectionNotFound;
 }
 

--- a/src/FSD/FSD_CmpFile.cxx
+++ b/src/FSD/FSD_CmpFile.cxx
@@ -69,7 +69,7 @@ Storage_Error FSD_CmpFile::Open(const TCollection_AsciiString& aName, const Stor
   SetName(aName);
 
   if (OpenMode() == Storage_VSNone) {
-    std::ios_base::openmode anOpenMode = std::ios_base::openmode(0);
+    std::ios_base::openmode anOpenMode = std::ios_base::openmode{};
     switch (aMode)
     {
     case Storage_VSNone:

--- a/src/FSD/FSD_File.cxx
+++ b/src/FSD/FSD_File.cxx
@@ -84,7 +84,7 @@ Storage_Error FSD_File::Open(const TCollection_AsciiString& aName,const Storage_
 
   if (OpenMode() == Storage_VSNone)
   {
-    std::ios_base::openmode anOpenMode = std::ios_base::openmode(0);
+    std::ios_base::openmode anOpenMode = std::ios_base::openmode{};
     switch (aMode)
     {
       case Storage_VSNone:
@@ -237,7 +237,7 @@ void FSD_File::WriteExtendedLine(const TCollection_ExtendedString& buffer)
 void FSD_File::ReadExtendedLine(TCollection_ExtendedString& buffer)
 {
   char c = '\0';
-  Standard_ExtCharacter i = 0,j,count = 0;
+  Standard_ExtCharacter i = 0,count = 0;
   Standard_Boolean fin = Standard_False;
   Standard_CString tg = ENDOFNORMALEXTENDEDSECTION;
  
@@ -249,7 +249,6 @@ void FSD_File::ReadExtendedLine(TCollection_ExtendedString& buffer)
     if (c == tg[count]) count++;
     else count = 0;
     if (count < SIZEOFNORMALEXTENDEDSECTION) {
-      j = 0;
       i = (Standard_ExtCharacter)c;
       if (c == '\0') fin = Standard_True;
       i = (i << 8);
@@ -258,10 +257,9 @@ void FSD_File::ReadExtendedLine(TCollection_ExtendedString& buffer)
       if (c == tg[count]) count++;
       else count = 0;
       if (count < SIZEOFNORMALEXTENDEDSECTION) {
-	j = (Standard_ExtCharacter)c;
 	if (c != '\n') {
 	  fin = Standard_False;
-	  i |= (0x00FF & j);
+	  i |= (0x00FF & (Standard_ExtCharacter)c);
 	  buffer += (Standard_ExtCharacter)i;
 	}
       }

--- a/src/Geom/Geom_BezierSurface.cxx
+++ b/src/Geom/Geom_BezierSurface.cxx
@@ -404,10 +404,9 @@ Geom_BezierSurface::Geom_BezierSurface
     throw Standard_ConstructionError();
   }
   
-  Standard_Integer Row = PoleWeights.LowerRow();
   Standard_Integer Col = PoleWeights.LowerCol();
   while (Col <= PoleWeights.UpperCol()) {
-    Row = PoleWeights.LowerRow();
+    Standard_Integer Row = PoleWeights.LowerRow();
     while (Row <= PoleWeights.UpperRow()) {
       if (PoleWeights(Row, Col) <= gp::Resolution()) {
         throw Standard_ConstructionError();

--- a/src/Geom2dConvert/Geom2dConvert_ApproxArcsSegments.cxx
+++ b/src/Geom2dConvert/Geom2dConvert_ApproxArcsSegments.cxx
@@ -746,7 +746,6 @@ Standard_Boolean Geom2dConvert_ApproxArcsSegments::checkCurve
   Standard_Boolean isCircle = (!isLine);
   if (isLine)
     aLin2d = aGeomLine->Lin2d();
-
   else {
     Handle(Geom2d_Circle) aGeomCircle =
       Handle(Geom2d_Circle)::DownCast(aCurve1);
@@ -786,7 +785,6 @@ Standard_Boolean Geom2dConvert_ApproxArcsSegments::checkCurve
       aParameterCurve = ElCLib::Parameter(aCirc2d, aPointAdaptor);
       aProjPoint = ElCLib::Value(aParameterCurve, aCirc2d);
     }
-    else isLess = Standard_False;
 
     isLess = (aProjPoint.Distance(aPointAdaptor) <
               myTolerance + Precision::PConfusion());

--- a/src/GeomAdaptor/GeomAdaptor_Surface.cxx
+++ b/src/GeomAdaptor/GeomAdaptor_Surface.cxx
@@ -449,15 +449,12 @@ Standard_Integer GeomAdaptor_Surface::NbVIntervals(const GeomAbs_Shape S) const
 
 void GeomAdaptor_Surface::UIntervals(TColStd_Array1OfReal& T, const GeomAbs_Shape S) const
 {
-  Standard_Integer myNbUIntervals = 1;
-
   switch (mySurfaceType)
   {
     case GeomAbs_BSplineSurface:
     {
       GeomAdaptor_Curve myBasisCurve
         (myBSplineSurface->VIso(myBSplineSurface->VKnot(myBSplineSurface->FirstVKnotIndex())),myUFirst,myULast);
-      myNbUIntervals = myBasisCurve.NbIntervals(S);
       myBasisCurve.Intervals(T,S);
       return;
     }
@@ -467,7 +464,6 @@ void GeomAdaptor_Surface::UIntervals(TColStd_Array1OfReal& T, const GeomAbs_Shap
         (Handle(Geom_SurfaceOfLinearExtrusion)::DownCast (mySurface)->BasisCurve(),myUFirst,myULast);
       if (myBasisCurve.GetType() == GeomAbs_BSplineCurve)
       {
-        myNbUIntervals = myBasisCurve.NbIntervals(S);
         myBasisCurve.Intervals(T,S);
         return;
       }
@@ -488,7 +484,6 @@ void GeomAdaptor_Surface::UIntervals(TColStd_Array1OfReal& T, const GeomAbs_Shap
       }
       Handle(Geom_OffsetSurface) myOffSurf = Handle(Geom_OffsetSurface)::DownCast(mySurface);
       GeomAdaptor_Surface Sur(myOffSurf->BasisSurface(), myUFirst, myULast, myVFirst, myVLast);
-      myNbUIntervals = Sur.NbUIntervals(BaseS);
       Sur.UIntervals(T, BaseS);
       return;
     }
@@ -503,7 +498,7 @@ void GeomAdaptor_Surface::UIntervals(TColStd_Array1OfReal& T, const GeomAbs_Shap
   }
 
   T(T.Lower()) = myUFirst;
-  T(T.Lower() + myNbUIntervals) = myULast;
+  T(T.Lower() + 1) = myULast;
 }
 
 //=======================================================================
@@ -513,15 +508,12 @@ void GeomAdaptor_Surface::UIntervals(TColStd_Array1OfReal& T, const GeomAbs_Shap
 
 void GeomAdaptor_Surface::VIntervals(TColStd_Array1OfReal& T, const GeomAbs_Shape S) const
 {
-  Standard_Integer myNbVIntervals = 1;
-
   switch (mySurfaceType)
   {
     case GeomAbs_BSplineSurface:
     {
       GeomAdaptor_Curve myBasisCurve
         (myBSplineSurface->UIso(myBSplineSurface->UKnot(myBSplineSurface->FirstUKnotIndex())),myVFirst,myVLast);
-      myNbVIntervals = myBasisCurve.NbIntervals(S);
       myBasisCurve.Intervals(T,S);
       return;
     }
@@ -532,7 +524,6 @@ void GeomAdaptor_Surface::VIntervals(TColStd_Array1OfReal& T, const GeomAbs_Shap
       GeomAdaptor_Curve myBasisCurve(myRevSurf->BasisCurve(), myVFirst, myVLast);
       if (myBasisCurve.GetType() == GeomAbs_BSplineCurve)
       {
-        myNbVIntervals = myBasisCurve.NbIntervals(S);
         myBasisCurve.Intervals(T,S);
         return;
       }
@@ -553,7 +544,6 @@ void GeomAdaptor_Surface::VIntervals(TColStd_Array1OfReal& T, const GeomAbs_Shap
       }
       Handle(Geom_OffsetSurface) myOffSurf = Handle(Geom_OffsetSurface)::DownCast(mySurface);
       GeomAdaptor_Surface Sur(myOffSurf->BasisSurface(), myUFirst, myULast, myVFirst, myVLast);
-      myNbVIntervals = Sur.NbVIntervals(BaseS);
       Sur.VIntervals(T, BaseS);
       return;
     }
@@ -568,7 +558,7 @@ void GeomAdaptor_Surface::VIntervals(TColStd_Array1OfReal& T, const GeomAbs_Shap
   }
   
   T(T.Lower()) = myVFirst;
-  T(T.Lower() + myNbVIntervals) = myVLast;
+  T(T.Lower() + 1) = myVLast;
 }
 
 //=======================================================================

--- a/src/GeomLib/GeomLib.cxx
+++ b/src/GeomLib/GeomLib.cxx
@@ -539,9 +539,6 @@ void GeomLib::EvalMaxDistanceAlongParameter(const Adaptor3d_Curve& ACurve,
     local_distance_squared =
       Point1.SquareDistance (Point2) ;
     
-    local_distance_squared =
-      Point1.SquareDistance (Point2) ;
-    
     
     if (local_distance_squared > tolerance_squared) {
       
@@ -1508,7 +1505,6 @@ void GeomLib::ExtendSurfByLength(Handle(Geom_BoundedSurface)& Surface,
 //   Standard_Boolean rational = ( InU && BS->IsURational() ) 
 //                                   || ( !InU && BS->IsVRational() ) ;
   Standard_Boolean rational = (BS->IsURational() ||  BS->IsVRational());
-  Standard_Boolean NullWeight;
   constexpr Standard_Real EpsW = 10*Precision::PConfusion();
   Standard_Integer gap = 3;
   if ( rational ) gap++;
@@ -1739,7 +1735,7 @@ void GeomLib::ExtendSurfByLength(Handle(Geom_BoundedSurface)& Surface,
     TColStd_Array2OfReal& NewW = NewWeights->ChangeArray2();
 
     if (!rational) NewW.Init(1.);
-    NullWeight= Standard_False;
+    Standard_Boolean NullWeight= Standard_False;
 
     if (InU) {
       for (ii=1; ii<=NU && !NullWeight; ii++) {
@@ -1791,7 +1787,6 @@ void GeomLib::ExtendSurfByLength(Handle(Geom_BoundedSurface)& Surface,
       std::cout << "Echec de l'Extension rationnelle" << std::endl;    
 #endif
       lambmin /= 3.;
-      NullWeight = Standard_False;
     }
     else {
       ExtOk = Standard_True;

--- a/src/IntAna2d/IntAna2d_AnaIntersection_2.cxx
+++ b/src/IntAna2d/IntAna2d_AnaIntersection_2.cxx
@@ -78,9 +78,7 @@ void IntAna2d_AnaIntersection::Perform (const gp_Circ2d& C1,
     Standard_Real ref2=Ox2.Angle(ax);                       // Resultat entre -PI et +PI
 
     Standard_Real l1=(d*d + R1*R1 -R2*R2)/(2.0*d);
-    Standard_Real aDet = R1*R1-l1*l1;
-    if(aDet < 0.) {
-      aDet = 0.;
+    if(R1*R1-l1*l1 < 0.) {
       l1 = (l1 > 0 ? R1 : - R1);
     }
     Standard_Real h= Sqrt(R1*R1-l1*l1);

--- a/src/Message/Message_Msg.cxx
+++ b/src/Message/Message_Msg.cxx
@@ -138,7 +138,6 @@ void Message_Msg::Set (const TCollection_ExtendedString& theMsg)
         aFormatType = Msg_StringType;
         break;
       default:
-        aFormatType = Msg_IndefiniteType;
         continue;
       }
       mySeqOfFormats.Append (Standard_Integer(aFormatType));  // type

--- a/src/Message/Message_PrinterOStream.cxx
+++ b/src/Message/Message_PrinterOStream.cxx
@@ -223,7 +223,7 @@ void Message_PrinterOStream::SetConsoleTextColor (Standard_OStream* theOStream,
     return;
   }
 
-  const char* aCode = "\e[0m";
+  const char* aCode;
   switch (theTextColor)
   {
     case Message_ConsoleColor_Default:

--- a/src/NCollection/NCollection_Array1.hxx
+++ b/src/NCollection/NCollection_Array1.hxx
@@ -26,8 +26,6 @@
 #include <NCollection_IndexedIterator.hxx>
 
 #include <algorithm>
-#include <array>
-#include <vector>
 
 //! The class NCollection_Array1 represents unidimensional arrays of fixed size known at run time.
 //! The range of the index is user defined.

--- a/src/OSD/OSD_File.cxx
+++ b/src/OSD/OSD_File.cxx
@@ -459,7 +459,7 @@ void OSD_File::Build (const OSD_OpenMode theMode,
     throw Standard_ProgramError ("OSD_File::Build(): no name was given");
   }
 
-  const char* anFDOpenMode = "r";
+  const char* anFDOpenMode;
   Standard_Integer anOpenMode = O_CREAT | O_TRUNC;
   switch (theMode)
   {
@@ -544,7 +544,7 @@ void OSD_File::Append (const OSD_OpenMode theMode,
     throw Standard_ProgramError ("OSD_File::Append(): no name was given");
   }
 
-  const char* anFDOpenMode = "r";
+  const char* anFDOpenMode;
   Standard_Integer anOpenMode = O_APPEND;
   switch (theMode)
   {
@@ -622,7 +622,7 @@ void OSD_File::Open (const OSD_OpenMode theMode,
     throw Standard_ProgramError ("OSD_File::Open(): no name was given");
   }
 
-  const char* anFDOpenMode = "r";
+  const char* anFDOpenMode;
   Standard_Integer anOpenMode = 0;
   switch (theMode)
   {

--- a/src/OSD/OSD_Path.cxx
+++ b/src/OSD/OSD_Path.cxx
@@ -115,7 +115,7 @@ static void VmsExtract(const TCollection_AsciiString& what,
   trek = buffer.Token("[]");
 
   if (trek.Value(1) == '.') trek.Remove(1,1);  // Removes first '.'
-    else trek.Insert(1,'|');                   // Add root
+  else trek.Insert(1,'|');                   // Add root
 
   trek.ChangeAll('.','|');   // Translates to portable syntax
   trek.ChangeAll('-','^');  
@@ -699,7 +699,7 @@ OSD_SysType pType;
     }
 
     if (Way.Length()!=0)
-     FullName = FullName + Way + "\\";
+      FullName = FullName + Way + "\\";
     
     FullName += myName; 
     FullName += myExtension;
@@ -1521,7 +1521,6 @@ TCollection_AsciiString OSD_Path::RelativePath(
   TCollection_AsciiString EmptyString = "" ;
   TCollection_AsciiString FilePath ;
   Standard_Integer len ;
-  Standard_Integer i, n ;
   Standard_Boolean Wnt = 0 ;
 
   FilePath = aAbsFilePath ;
@@ -1554,14 +1553,14 @@ TCollection_AsciiString OSD_Path::RelativePath(
   TCollection_AsciiString DirToken, FileToken ;
   Standard_Boolean Sibling = 0 ;
 
-  for (i = n = 1 ;; n++) {
+  for (Standard_Integer n = 1 ;; n++) {
       DirToken = aDirPath.Token("/\\",n) ;
       if (DirToken.IsEmpty())
           return FilePath ;
 
       if (!Sibling) {
           len = FilePath.Length() ;
-          i = FilePath.Search("/") ;
+          Standard_Integer i = FilePath.Search("/") ;
           if (i > 0) {
               if (i == len)
                   return EmptyString ;

--- a/src/Resource/Resource_Unicode.cxx
+++ b/src/Resource/Resource_Unicode.cxx
@@ -149,9 +149,6 @@ Standard_Boolean Resource_Unicode::ConvertGBKToUnicode(const Standard_CString fr
         tostr.Insert(0, curext3);
         tostr.Insert(0, curext2);
         tostr.Insert(0, curext1);
-        gb1 = 0;
-        gb2 = 0;
-        gb3 = 0;
         return Standard_False;
       }
 
@@ -180,8 +177,6 @@ Standard_Boolean Resource_Unicode::ConvertGBKToUnicode(const Standard_CString fr
       TCollection_ExtendedString curext1(((char) gb2));
       tostr.Insert(0, curext2);
       tostr.Insert(0, curext1);
-      gb1 = 0;
-      gb2 = 0;
       return Standard_False;
     }
     else if (gb1 != 0x00)
@@ -387,7 +382,6 @@ Standard_Boolean Resource_Unicode::ConvertUnicodeToSJIS(const TCollection_Extend
 	}
 	else {
 	  tostr[nbtrans] = '\0';
-	  nbtrans = maxsize-1;
 	  return Standard_False;
 	}
       }
@@ -397,7 +391,6 @@ Standard_Boolean Resource_Unicode::ConvertUnicodeToSJIS(const TCollection_Extend
       }
       if (nbtrans >= (maxsize - 1)) {
 	tostr[maxsize-1] = '\0';
-	finished = Standard_True;
 	return Standard_False;
       }
     }
@@ -436,7 +429,6 @@ Standard_Boolean Resource_Unicode::ConvertUnicodeToEUC(const TCollection_Extende
 	}
 	else {
 	  tostr[nbtrans-1] = '\0';
-	  nbtrans = maxsize-1;
 	  return Standard_False;
 	}
       }
@@ -446,7 +438,6 @@ Standard_Boolean Resource_Unicode::ConvertUnicodeToEUC(const TCollection_Extende
       }
       if (nbtrans >= (maxsize - 1)) {
 	tostr[maxsize-1] = '\0';
-	finished = Standard_True;
 	return Standard_False;
       }
     }
@@ -485,7 +476,6 @@ Standard_Boolean Resource_Unicode::ConvertUnicodeToGB(const TCollection_Extended
 	}
 	else {
 	  tostr[nbtrans-1] = '\0';
-	  nbtrans = maxsize-1;
 	  return Standard_False;
 	}
       }
@@ -495,7 +485,6 @@ Standard_Boolean Resource_Unicode::ConvertUnicodeToGB(const TCollection_Extended
       }
       if (nbtrans >= (maxsize - 1)) {
 	tostr[maxsize-1] = '\0';
-	finished = Standard_True;
 	return Standard_False;
       }
     }
@@ -534,7 +523,6 @@ Standard_Boolean Resource_Unicode::ConvertUnicodeToANSI(const TCollection_Extend
     }
     if (nbtrans >= (maxsize - 1)) {
       tostr[maxsize-1] = '\0';
-      finished = Standard_True;
       return Standard_False;
     }
   }

--- a/src/Standard/Standard_Dump.cxx
+++ b/src/Standard/Standard_Dump.cxx
@@ -160,7 +160,10 @@ Standard_Boolean Standard_Dump::InitRealValues (const TCollection_AsciiString& t
     TCollection_AsciiString aValueText = aSubText.SubString (aStreamPos, aNextPos - 1);
 
     if (!aValueText.IsRealValue())
+    {
+      va_end(vl);
       return Standard_False;
+    }
 
     Standard_Real aValue = aValueText.RealValue();
     *(va_arg(vl, Standard_Real*)) = aValue;

--- a/src/Standard/Standard_Failure.cxx
+++ b/src/Standard/Standard_Failure.cxx
@@ -44,7 +44,7 @@ Standard_Failure::StringRef* Standard_Failure::StringRef::allocate_message (cons
   }
 
   const Standard_Size aLen = strlen (theString);
-  StringRef* aStrPtr = (StringRef* )malloc (aLen + sizeof(Standard_Integer) + 1);
+  StringRef* aStrPtr = (StringRef*)Standard::AllocateOptimal (aLen + sizeof(Standard_Integer) + 1);
   if (aStrPtr != NULL)
   {
     strcpy ((char* )&aStrPtr->Message[0], theString);
@@ -78,7 +78,7 @@ void Standard_Failure::StringRef::deallocate_message (Standard_Failure::StringRe
   {
     if (--theString->Counter == 0)
     {
-      free ((void* )theString);
+      Standard::Free ((void* )theString);
     }
   }
 }

--- a/src/Standard/Standard_GUID.cxx
+++ b/src/Standard/Standard_GUID.cxx
@@ -192,7 +192,7 @@ Standard_GUID::Standard_GUID(const Standard_CString aGuid)
   tmpBuffer = Standard_GUID_GetValue8(tmpBuffer,my8b3);
   tmpBuffer = Standard_GUID_GetValue8(tmpBuffer,my8b4);
   tmpBuffer = Standard_GUID_GetValue8(tmpBuffer,my8b5);
-  tmpBuffer = Standard_GUID_GetValue8(tmpBuffer,my8b6);
+  Standard_GUID_GetValue8(tmpBuffer,my8b6);
 }
 
 Standard_GUID::Standard_GUID(const Standard_ExtString aGuid) 
@@ -232,7 +232,7 @@ Standard_GUID::Standard_GUID(const Standard_ExtString aGuid)
   tmpBuffer = Standard_GUID_GetValue8(tmpBuffer,my8b3);
   tmpBuffer = Standard_GUID_GetValue8(tmpBuffer,my8b4);
   tmpBuffer = Standard_GUID_GetValue8(tmpBuffer,my8b5);
-  tmpBuffer = Standard_GUID_GetValue8(tmpBuffer,my8b6);
+  Standard_GUID_GetValue8(tmpBuffer,my8b6);
 }
 
 Standard_GUID::Standard_GUID(const Standard_Integer a32b,

--- a/src/Units/Units_UnitsDictionary.cxx
+++ b/src/Units/Units_UnitsDictionary.cxx
@@ -298,7 +298,6 @@ void Units_UnitsDictionary::Creates()
       }
 
       if(unit2[0]) {
-        j = 0;
         for(j=1;j<=theunitssequence->Length();j++)
           if(theunitssequence->Value(j) == unit2)break;
 

--- a/src/gp/gp_Mat.cxx
+++ b/src/gp/gp_Mat.cxx
@@ -222,9 +222,7 @@ void gp_Mat::Invert()
   aNewMat[1][2] = -(myMat[0][0] * myMat[1][2] - myMat[1][0] * myMat[0][2]);
   aNewMat[2][2] =   myMat[0][0] * myMat[1][1] - myMat[0][1] * myMat[1][0];
   Standard_Real aDet =  myMat[0][0] * aNewMat[0][0] + myMat[0][1]* aNewMat[1][0] + myMat[0][2] * aNewMat[2][0];
-  Standard_Real aVal = aDet;
-  if (aVal < 0) aVal = -aVal;
-  Standard_ConstructionError_Raise_if (aVal <= gp::Resolution(), "gp_Mat::Invert() - matrix has zero determinant");
+  Standard_ConstructionError_Raise_if (Abs(aDet) <= gp::Resolution(), "gp_Mat::Invert() - matrix has zero determinant");
   aDet = 1.0e0 / aDet;
   myMat[0][0] = aNewMat[0][0];
   myMat[1][0] = aNewMat[1][0];
@@ -256,9 +254,7 @@ gp_Mat gp_Mat::Inverted() const
   aNewMat.myMat[1][2] = -(myMat[0][0] * myMat[1][2] - myMat[1][0] * myMat[0][2]);
   aNewMat.myMat[2][2] =   myMat[0][0] * myMat[1][1] - myMat[0][1] * myMat[1][0];
   Standard_Real aDet =  myMat[0][0] * aNewMat.myMat[0][0] + myMat[0][1]* aNewMat.myMat[1][0] + myMat[0][2] * aNewMat.myMat[2][0];
-  Standard_Real aVal =  aDet;
-  if (aVal < 0) aVal = -aVal;
-  Standard_ConstructionError_Raise_if (aVal <= gp::Resolution(), "gp_Mat::Inverted() - matrix has zero determinant");
+  Standard_ConstructionError_Raise_if (Abs(aDet) <= gp::Resolution(), "gp_Mat::Inverted() - matrix has zero determinant");
   aDet = 1.0e0 / aDet;
   aNewMat.Multiply (aDet);
   return aNewMat;

--- a/src/gp/gp_Mat2d.cxx
+++ b/src/gp/gp_Mat2d.cxx
@@ -144,9 +144,7 @@ void gp_Mat2d::Invert()
   aNewMat[1][0] = -myMat[1][0];
   aNewMat[1][1] =  myMat[0][0];
   Standard_Real aDet = aNewMat[0][0] * aNewMat[1][1] - aNewMat[0][1] * aNewMat[1][0];
-  Standard_Real val = aDet;
-  if (val < 0) val = - val;
-  Standard_ConstructionError_Raise_if (val <= gp::Resolution(), "gp_Mat2d::Invert() - matrix has zero determinant");
+  Standard_ConstructionError_Raise_if (Abs(aDet) <= gp::Resolution(), "gp_Mat2d::Invert() - matrix has zero determinant");
   aDet = 1.0 / aDet;
   myMat[0][0] = aNewMat[0][0] * aDet;
   myMat[1][0] = aNewMat[1][0] * aDet;

--- a/src/math/math_BissecNewton.cxx
+++ b/src/math/math_BissecNewton.cxx
@@ -52,7 +52,7 @@ void math_BissecNewton::Perform(math_FunctionWithDerivative& F,
   Standard_Boolean GOOD;
   Standard_Integer j;
   Standard_Real dxold, fh, fl;
-  Standard_Real swap, temp, xh, xl;
+  Standard_Real temp, xh, xl;
   
   GOOD = F.Values(Bound1, fl, df);
   if(!GOOD) {
@@ -83,9 +83,6 @@ void math_BissecNewton::Perform(math_FunctionWithDerivative& F,
   else {
     xl = Bound2;
     xh = Bound1;
-    swap = fl;
-    fl = fh;
-    fh = swap;
   }
 //  Modified by Sergey KHROMOV - Wed Jan 22 12:06:49 2003 End
   x = 0.5 * (Bound1 + Bound2);
@@ -133,11 +130,9 @@ void math_BissecNewton::Perform(math_FunctionWithDerivative& F,
     }
     if(f < 0.0) {
       xl = x;
-      fl = f;
     }
     else if(f > 0.0) {
       xh = x;
-      fh = f;
     }
     else {
       TheStatus = math_OK;

--- a/src/math/math_Householder.cxx
+++ b/src/math/math_Householder.cxx
@@ -90,7 +90,7 @@ void math_Householder::Perform(const math_Matrix& A, const math_Matrix& B,
                                const Standard_Real EPS) {
 
   Standard_Integer i, j, k, n, l, m;
-  Standard_Real scale, f, g, h = 0., alfaii;
+  Standard_Real f, g, h = 0., alfaii;
   Standard_Real qki;
   Standard_Real cj;
   n = Q.ColNumber();
@@ -112,7 +112,7 @@ void math_Householder::Perform(const math_Matrix& A, const math_Matrix& B,
 
 // Traitement de chaque colonne de A:
     for (i = 1; i <= n; i++) {
-      h = scale = 0.0;
+      h = 0.0;
         for (k = i; k <= l; k++) {
           qki = Q(k, i);
 	  h += qki*qki;                           // = ||a||*||a||     = EUAI
@@ -126,7 +126,7 @@ void math_Householder::Perform(const math_Matrix& A, const math_Matrix& B,
         h -= f*g;                                 // = (v*v)/2         = C1
         alfaii = g-f;                             // = v               = ALFAII
         for (j =i+1; j <= n; j++) {
-     	  scale = 0.0;
+     	  Standard_Real scale = 0.0;
 	  for (k = i; k <= l; k++) {
 	   scale += Q(k,i)* Q(k,j);                //                   = SCAL
 	  }
@@ -140,7 +140,7 @@ void math_Householder::Perform(const math_Matrix& A, const math_Matrix& B,
 // Modification de B:
 
         for (j = 1; j <= m; j++) {
-          scale= Q(i,i)*B2(i,j);
+           Standard_Real scale= Q(i,i)*B2(i,j);
           for (k = i+1; k <= l; k++) {
 	    scale += Q(k,i)*B2(k,j);
 	  }
@@ -158,7 +158,7 @@ void math_Householder::Perform(const math_Matrix& A, const math_Matrix& B,
   for (j = 1; j <= m; j++) {
     Sol(n,j) = B2(n,j)/Q(n,n);
     for (i = n -1; i >=1; i--) {
-      scale= 0.0;
+      Standard_Real scale= 0.0;
       for(k = i+1; k <= n; k++) {
 	scale += Q(i,k) * Sol(k,j);
       }

--- a/src/math/math_NewtonMinimum.cxx
+++ b/src/math/math_NewtonMinimum.cxx
@@ -92,7 +92,6 @@ void math_NewtonMinimum::Perform(math_MultipleVarFunctionWithHessian& F,
   math_Vector Point2(1, F.NbVariables());
   math_Vector* precedent = &Point1;
   math_Vector* suivant = &Point2;
-  math_Vector* auxiliaire = precedent;
 
   Standard_Boolean Ok = Standard_True;
   Standard_Integer NbConv = 0, ii, Nreduction;
@@ -234,7 +233,7 @@ void math_NewtonMinimum::Perform(math_MultipleVarFunctionWithHessian& F,
     }
 
     if (VItere <= VPrecedent) {
-       auxiliaire =  precedent;
+       math_Vector* auxiliaire =  precedent;
        precedent = suivant;
        suivant = auxiliaire;
        PreviousMinimum = VPrecedent;

--- a/src/math/math_Recipes.cxx
+++ b/src/math/math_Recipes.cxx
@@ -314,7 +314,7 @@ Standard_Integer SVD_Decompose(math_Matrix& a,
                      math_Vector& rv1) {
 
      Standard_Integer flag, i, its, j, jj, k, l=0, nm=0;
-     Standard_Real ar, aw, aik, aki, c, f, h, s, x, y, z;
+     Standard_Real ar, aw, aik, aki, f, h, s, x, y, z;
      Standard_Real anorm = 0.0, g = 0.0, scale = 0.0;
      Standard_Integer m = a.RowNumber();
      Standard_Integer n = a.ColNumber();
@@ -445,7 +445,6 @@ Standard_Integer SVD_Decompose(math_Matrix& a,
            if(fabs(w(nm)) + anorm == anorm) break;
          }
          if(flag) {
-           c = 0.0;
            s = 1.0;
            for(i = l; i <= k; i++) {
              f = s * rv1(i);
@@ -454,7 +453,7 @@ Standard_Integer SVD_Decompose(math_Matrix& a,
                h = PYTHAG(f, g);
                w(i) = h;
                h = 1.0 / h;
-               c = g * h;
+               Standard_Real c = g * h;
                s = (-f * h);
                for(j = 1; j <= m; j++) {
                  y = a(j,nm);
@@ -486,7 +485,7 @@ Standard_Integer SVD_Decompose(math_Matrix& a,
          g = PYTHAG(f, 1.0);
          f = ((x - z) * (x + z) + h * ((y / ( f + SIGN(g, f))) - h)) / x;
          
-         c = s = 1.0;
+         Standard_Real c = s = 1.0;
          for(j = l; j <= nm; j++) {
            i = j + 1;
            g = rv1(i);


### PR DESCRIPTION
First iteration for fixing warnings for:
- TKernel
- TKMath
- TKGeomBase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling and validation for various mathematical and geometric operations.
	- Improved handling of file opening modes in file management classes.
	- Added checks for pole weights in Bezier surface management.

- **Bug Fixes**
	- Streamlined logic for distance calculations in extremum finding algorithms.
	- Fixed issues related to curve parameter handling in bounding box calculations.

- **Documentation**
	- Updated comments and internal documentation for clarity on recent changes.

- **Refactor**
	- Simplified control flows and variable declarations across multiple classes to improve code readability and maintainability.

- **Style**
	- Improved formatting and consistency in code style, including variable initialization and spacing.

- **Tests**
	- Enhanced error handling in various methods to prevent runtime errors and improve robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->