### PR TITLE
Visualization - Unexpected moving with AIS_ViewCube

### DIFF
--- a/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ViewerCommands.cxx
+++ b/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ViewerCommands.cxx
@@ -6375,16 +6375,14 @@ static Standard_Integer VMoveTo(Draw_Interpretor& theDI,
   return 0;
 }
 
-//=======================================================================
-//function : VMouseButton
-//purpose  : Emulates mouse button event
-//=======================================================================
+//=================================================================================================
+
 static Standard_Integer VMouseButton(Draw_Interpretor& /*theDI*/,
-  Standard_Integer theNbArgs,
-  const char** theArgVec)
+                                     Standard_Integer theNbArgs,
+                                     const char**     theArgVec)
 {
   const Handle(AIS_InteractiveContext)& aContext = ViewerTest::GetAISContext();
-  const Handle(V3d_View)& aView = ViewerTest::CurrentView();
+  const Handle(V3d_View)&               aView    = ViewerTest::CurrentView();
   if (aContext.IsNull())
   {
     Message::SendFail("Error: no active viewer");
@@ -6397,7 +6395,7 @@ static Standard_Integer VMouseButton(Draw_Interpretor& /*theDI*/,
     return 1;
   }
 
-  Aspect_VKeyMouse aButton = Aspect_VKeyMouse_LeftButton;
+  Aspect_VKeyMouse aButton       = Aspect_VKeyMouse_LeftButton;
   Standard_Boolean isPressButton = false;
   Standard_Boolean hasActionFlag = false;
 
@@ -6412,6 +6410,7 @@ static Standard_Integer VMouseButton(Draw_Interpretor& /*theDI*/,
       {
         ++anArgIter;
         TCollection_AsciiString aButtonStr(theArgVec[anArgIter]);
+        aButtonStr.LowerCase();
         if (aButtonStr == "left")
         {
           aButton = Aspect_VKeyMouse_LeftButton;
@@ -6447,13 +6446,11 @@ static Standard_Integer VMouseButton(Draw_Interpretor& /*theDI*/,
       isPressButton = true;
       hasActionFlag = true;
     }
-    else if (aMousePos.x() == IntegerLast()
-      && anArgStr.IsIntegerValue())
+    else if (aMousePos.x() == IntegerLast() && anArgStr.IsIntegerValue())
     {
       aMousePos.x() = anArgStr.IntegerValue();
     }
-    else if (aMousePos.y() == IntegerLast()
-      && anArgStr.IsIntegerValue())
+    else if (aMousePos.y() == IntegerLast() && anArgStr.IsIntegerValue())
     {
       aMousePos.y() = anArgStr.IntegerValue();
     }
@@ -6464,8 +6461,7 @@ static Standard_Integer VMouseButton(Draw_Interpretor& /*theDI*/,
     }
   }
 
-  if (aMousePos.x() == IntegerLast()
-    || aMousePos.y() == IntegerLast())
+  if (aMousePos.x() == IntegerLast() || aMousePos.y() == IntegerLast())
   {
     Message::SendFail("Syntax error: mouse coordinates (x y) are required");
     return 1;
@@ -6480,14 +6476,26 @@ static Standard_Integer VMouseButton(Draw_Interpretor& /*theDI*/,
   if (isPressButton)
   {
     ViewerTest::CurrentEventManager()->ResetPreviousMoveTo();
-    ViewerTest::CurrentEventManager()->PressMouseButton(aMousePos, aButton, Aspect_VKeyFlags_NONE, false);
-    ViewerTest::CurrentEventManager()->UpdateMousePosition(aMousePos, Aspect_VKeyMouse_NONE, Aspect_VKeyFlags_NONE, false);
+    ViewerTest::CurrentEventManager()->PressMouseButton(aMousePos,
+                                                        aButton,
+                                                        Aspect_VKeyFlags_NONE,
+                                                        false);
+    ViewerTest::CurrentEventManager()->UpdateMousePosition(aMousePos,
+                                                           Aspect_VKeyMouse_NONE,
+                                                           Aspect_VKeyFlags_NONE,
+                                                           false);
     ViewerTest::CurrentEventManager()->FlushViewEvents(ViewerTest::GetAISContext(), aView, true);
   }
   else
   {
-    ViewerTest::CurrentEventManager()->UpdateMousePosition(aMousePos, Aspect_VKeyMouse_NONE, Aspect_VKeyFlags_NONE, false);
-    ViewerTest::CurrentEventManager()->ReleaseMouseButton(aMousePos, aButton, Aspect_VKeyFlags_NONE, false);
+    ViewerTest::CurrentEventManager()->UpdateMousePosition(aMousePos,
+                                                           Aspect_VKeyMouse_NONE,
+                                                           Aspect_VKeyFlags_NONE,
+                                                           false);
+    ViewerTest::CurrentEventManager()->ReleaseMouseButton(aMousePos,
+                                                          aButton,
+                                                          Aspect_VKeyFlags_NONE,
+                                                          false);
     ViewerTest::CurrentEventManager()->FlushViewEvents(ViewerTest::GetAISContext(), aView, true);
   }
 

--- a/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ViewerCommands.cxx
+++ b/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ViewerCommands.cxx
@@ -6424,6 +6424,17 @@ static Standard_Integer VMouseButton(Draw_Interpretor& /*theDI*/,
         {
           aButton = Aspect_VKeyMouse_MiddleButton;
         }
+        else
+        {
+          Message::SendFail() << "Syntax error: invalid button name '" << aButtonStr
+                              << "' (valid options: left, right, middle)";
+          return 1;
+        }
+      }
+      else
+      {
+        Message::SendFail("Syntax error: -button option requires a value (left, right, middle)");
+        return 1;
       }
     }
     else if (anArgStr == "-up")

--- a/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ViewerCommands.cxx
+++ b/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ViewerCommands.cxx
@@ -6391,7 +6391,7 @@ static Standard_Integer VMouseButton(Draw_Interpretor& /*theDI*/,
     return 1;
   }
 
-  if (theNbArgs < 6)
+  if (theNbArgs < 4)
   {
     Message::SendFail("Syntax error: wrong number arguments");
     return 1;
@@ -6399,6 +6399,7 @@ static Standard_Integer VMouseButton(Draw_Interpretor& /*theDI*/,
 
   Aspect_VKeyMouse aButton = Aspect_VKeyMouse_LeftButton;
   Standard_Boolean isPressButton = false;
+  Standard_Boolean hasActionFlag = false;
 
   Graphic3d_Vec2i aMousePos(IntegerLast(), IntegerLast());
   for (Standard_Integer anArgIter = 1; anArgIter < theNbArgs; ++anArgIter)
@@ -6428,10 +6429,12 @@ static Standard_Integer VMouseButton(Draw_Interpretor& /*theDI*/,
     else if (anArgStr == "-up")
     {
       isPressButton = false;
+      hasActionFlag = true;
     }
     else if (anArgStr == "-down")
     {
       isPressButton = true;
+      hasActionFlag = true;
     }
     else if (aMousePos.x() == IntegerLast()
       && anArgStr.IsIntegerValue())
@@ -6453,7 +6456,13 @@ static Standard_Integer VMouseButton(Draw_Interpretor& /*theDI*/,
   if (aMousePos.x() == IntegerLast()
     || aMousePos.y() == IntegerLast())
   {
-    Message::SendFail("Syntax error: wrong number of arguments");
+    Message::SendFail("Syntax error: mouse coordinates (x y) are required");
+    return 1;
+  }
+
+  if (!hasActionFlag)
+  {
+    Message::SendFail("Syntax error: action flag (-up or -down) is required");
     return 1;
   }
 
@@ -6467,7 +6476,6 @@ static Standard_Integer VMouseButton(Draw_Interpretor& /*theDI*/,
   else
   {
     ViewerTest::CurrentEventManager()->UpdateMousePosition(aMousePos, Aspect_VKeyMouse_NONE, Aspect_VKeyFlags_NONE, false);
-    ViewerTest::CurrentEventManager()->FlushViewEvents(ViewerTest::GetAISContext(), aView, true);
     ViewerTest::CurrentEventManager()->ReleaseMouseButton(aMousePos, aButton, Aspect_VKeyFlags_NONE, false);
     ViewerTest::CurrentEventManager()->FlushViewEvents(ViewerTest::GetAISContext(), aView, true);
   }

--- a/src/Visualization/TKV3d/AIS/AIS_ViewController.cxx
+++ b/src/Visualization/TKV3d/AIS/AIS_ViewController.cxx
@@ -1794,7 +1794,7 @@ void AIS_ViewController::handleViewRotation(const Handle(V3d_View)& theView,
     const gp_Dir& aCamUp  = aCam->Up();
 
     // Build camera coordinate system
-    gp_Dir aCamRight = aCamDir.Crossed(aCamUp);
+    gp_Dir aCamRight = aCamUp.Crossed(aCamDir); // right-handed basis
     gp_Ax3 aCamCoordSys(gp::Origin(), aCamUp, aCamRight);
 
     // Create quaternion from camera coordinate system

--- a/src/Visualization/TKV3d/AIS/AIS_ViewController.cxx
+++ b/src/Visualization/TKV3d/AIS/AIS_ViewController.cxx
@@ -1791,7 +1791,7 @@ void AIS_ViewController::handleViewRotation(const Handle(V3d_View)& theView,
     // Store the current camera orientation as a quaternion
     // This avoids the numerical instability of Euler angle conversion
     const gp_Dir& aCamDir = aCam->Direction();
-    const gp_Dir& aCamUp  = aCam->Up();
+    const gp_Dir  aCamUp  = aCam->OrthogonalizedUp();
 
     // Build camera coordinate system
     gp_Dir aCamRight = aCamUp.Crossed(aCamDir); // right-handed basis
@@ -1868,8 +1868,8 @@ void AIS_ViewController::handleViewRotation(const Handle(V3d_View)& theView,
   aPitchRotation.SetVectorAndAngle(gp_Vec(aLocalRight),
                                    aPitchDelta); // Pitch around camera local right
 
-  // Combine rotations: apply pitch first, then yaw (correct order for camera control)
-  const gp_Quaternion aCombinedRotation = aYawRotation * aPitchRotation;
+  // Combine rotations: apply pitch first, then yaw (matches multiplication order)
+  const gp_Quaternion aCombinedRotation = aPitchRotation * aYawRotation;
 
   // Apply the rotation to the starting camera orientation
   gp_Quaternion aFinalRotation = aCombinedRotation * myRotateStartQuaternion;
@@ -1880,7 +1880,7 @@ void AIS_ViewController::handleViewRotation(const Handle(V3d_View)& theView,
     // Get the current view direction to use as roll axis
     gp_Trsf aPreRollTrsf;
     aPreRollTrsf.SetRotation(aFinalRotation);
-    const gp_Dir aViewDir = gp::DX().Transformed(aPreRollTrsf);
+    const gp_Dir aViewDir = -gp::DY().Transformed(aPreRollTrsf);
 
     gp_Quaternion aRollRotation;
     aRollRotation.SetVectorAndAngle(gp_Vec(aViewDir), theRoll); // Roll around view direction
@@ -1893,7 +1893,7 @@ void AIS_ViewController::handleViewRotation(const Handle(V3d_View)& theView,
 
   // Get the new camera directions from the world coordinate system
   const gp_Dir aNewUp  = gp::DZ().Transformed(aFinalTrsf);
-  const gp_Dir aNewDir = gp::DX().Transformed(aFinalTrsf);
+  const gp_Dir aNewDir = -gp::DY().Transformed(aFinalTrsf);
 
   // Apply to camera
   aCam->SetUp(aNewUp);

--- a/src/Visualization/TKV3d/AIS/AIS_ViewController.cxx
+++ b/src/Visualization/TKV3d/AIS/AIS_ViewController.cxx
@@ -29,7 +29,7 @@
 
 namespace
 {
-//! Extract camera up direction from quaternion (corresponds to Z-axis)
+// Extract camera up direction from quaternion (corresponds to Z-axis)
 inline gp_Dir QuaternionToUpDir(const gp_Quaternion& theQuaternion)
 {
   gp_Trsf aTrsf;
@@ -37,7 +37,7 @@ inline gp_Dir QuaternionToUpDir(const gp_Quaternion& theQuaternion)
   return gp::DZ().Transformed(aTrsf);
 }
 
-//! Extract camera right direction from quaternion (corresponds to X-axis)
+// Extract camera right direction from quaternion (corresponds to X-axis)
 inline gp_Dir QuaternionToRightDir(const gp_Quaternion& theQuaternion)
 {
   gp_Trsf aTrsf;
@@ -45,7 +45,7 @@ inline gp_Dir QuaternionToRightDir(const gp_Quaternion& theQuaternion)
   return gp::DX().Transformed(aTrsf);
 }
 
-//! Extract camera view direction from quaternion (corresponds to -Y-axis)
+// Extract camera view direction from quaternion (corresponds to -Y-axis)
 inline gp_Dir QuaternionToViewDir(const gp_Quaternion& theQuaternion)
 {
   gp_Trsf aTrsf;

--- a/src/Visualization/TKV3d/AIS/AIS_ViewController.cxx
+++ b/src/Visualization/TKV3d/AIS/AIS_ViewController.cxx
@@ -1811,7 +1811,6 @@ void AIS_ViewController::handleViewRotation(const Handle(V3d_View)& theView,
   }
 
   // Compute camera-local axes from current camera orientation for rotation calculations
-  // Use the already defined aCam from line 1780
   const gp_Dir&            aCamDir     = aCam->Direction();
   const gp_Dir             aCamUp      = aCam->OrthogonalizedUp();
   gp_Dir                   aLocalRight = aCamUp.Crossed(aCamDir); // Camera right (pitch axis)
@@ -1862,8 +1861,6 @@ void AIS_ViewController::handleViewRotation(const Handle(V3d_View)& theView,
   const double aRotationScale = M_PI_2;
   const double aYawDelta      = -aMouseDeltaX * aRotationScale;
   const double aPitchDelta    = aMouseDeltaY * aRotationScale;
-
-  // Use previously computed camera-local axes (computed above if rotation is needed)
 
   gp_Quaternion aYawRotation, aPitchRotation;
   aYawRotation.SetVectorAndAngle(gp_Vec(aLocalUp), aYawDelta); // Yaw around camera local up

--- a/src/Visualization/TKV3d/AIS/AIS_ViewController.cxx
+++ b/src/Visualization/TKV3d/AIS/AIS_ViewController.cxx
@@ -1857,7 +1857,7 @@ void AIS_ViewController::handleViewRotation(const Handle(V3d_View)& theView,
   aPitchRotation.SetVectorAndAngle(gp_Vec(gp::DX()), aPitchDelta); // Pitch around world X axis
 
   // Combine rotations: first pitch, then yaw
-  gp_Quaternion aCombinedRotation = aYawRotation * aPitchRotation;
+  const gp_Quaternion aCombinedRotation = aYawRotation * aPitchRotation;
 
   // Apply the rotation to the starting camera orientation
   gp_Quaternion aFinalRotation = aCombinedRotation * myRotateStartQuaternion;
@@ -1865,8 +1865,13 @@ void AIS_ViewController::handleViewRotation(const Handle(V3d_View)& theView,
   // Apply roll if specified
   if (Abs(theRoll) > gp::Resolution())
   {
+    // Get the current view direction to use as roll axis
+    gp_Trsf aPreRollTrsf;
+    aPreRollTrsf.SetRotation(aFinalRotation);
+    const gp_Dir aViewDir = gp::DX().Transformed(aPreRollTrsf);
+
     gp_Quaternion aRollRotation;
-    aRollRotation.SetVectorAndAngle(gp_Vec(gp::DY()), theRoll); // Roll around view direction
+    aRollRotation.SetVectorAndAngle(gp_Vec(aViewDir), theRoll); // Roll around view direction
     aFinalRotation = aRollRotation * aFinalRotation;
   }
 

--- a/src/Visualization/TKV3d/AIS/AIS_ViewController.hxx
+++ b/src/Visualization/TKV3d/AIS/AIS_ViewController.hxx
@@ -828,8 +828,8 @@ protected: //! @name rotation/panning transient state variables
   gp_Pnt              myCamStartOpCenter;         //!< camera Center position at the beginning of rotation
   gp_Vec              myCamStartOpToCenter;       //!< vector from rotation gravity point to camera Center at the beginning of rotation
   gp_Vec              myCamStartOpToEye;          //!< vector from rotation gravity point to camera Eye    at the beginning of rotation
-  Graphic3d_Vec3d     myRotateStartYawPitchRoll;  //!< camera yaw pitch roll at the beginning of rotation
-  gp_Quaternion       myRotateStartQuaternion;    //!< camera orientation quaternion at the beginning of rotation
+  Standard_Real       myRotateStartRoll;          //!< camera roll value for change detection in view rotation
+  gp_Quaternion       myRotateStartQuaternion;    //!< camera orientation quaternion at the beginning of view rotation
   // clang-format on
 };
 

--- a/src/Visualization/TKV3d/AIS/AIS_ViewController.hxx
+++ b/src/Visualization/TKV3d/AIS/AIS_ViewController.hxx
@@ -25,6 +25,7 @@
 #include <AIS_WalkDelta.hxx>
 
 #include <gp_Pnt.hxx>
+#include <gp_Quaternion.hxx>
 #include <Graphic3d_Vec3.hxx>
 #include <NCollection_Array1.hxx>
 #include <OSD_Timer.hxx>
@@ -828,6 +829,7 @@ protected: //! @name rotation/panning transient state variables
   gp_Vec              myCamStartOpToCenter;       //!< vector from rotation gravity point to camera Center at the beginning of rotation
   gp_Vec              myCamStartOpToEye;          //!< vector from rotation gravity point to camera Eye    at the beginning of rotation
   Graphic3d_Vec3d     myRotateStartYawPitchRoll;  //!< camera yaw pitch roll at the beginning of rotation
+  gp_Quaternion       myRotateStartQuaternion;    //!< camera orientation quaternion at the beginning of rotation
   // clang-format on
 };
 

--- a/src/Visualization/TKV3d/V3d/V3d_View.hxx
+++ b/src/Visualization/TKV3d/V3d/V3d_View.hxx
@@ -993,7 +993,7 @@ public:
                             const Graphic3d_BufferType& theBufferType     = Graphic3d_BT_RGB,
                             const Standard_Boolean      theToAdjustAspect = Standard_True,
                             const Graphic3d_ZLayerId theTargetZLayerId = Graphic3d_ZLayerId_BotOSD,
-                            const Standard_Integer   theIsSingleLayer  = Standard_False,
+                            const Standard_Boolean   theIsSingleLayer  = Standard_False,
                             const V3d_StereoDumpOptions theStereoOptions = V3d_SDO_MONO,
                             const Standard_CString      theLightName     = "")
   {

--- a/tests/v3d/bugs/bug33746
+++ b/tests/v3d/bugs/bug33746
@@ -1,0 +1,30 @@
+puts "============"
+puts "0033746: Visualization - Unexpected moving with AIS_ViewCube"
+puts "============"
+puts ""
+
+pload MODELING VISUALIZATION
+vclear
+vinit View1
+
+box b 0 0 -100 100 20 10
+vdisplay -dispMode 1 b
+
+vviewcube c
+vcamera -navmode fly
+
+vtop
+vfit
+vmousebutton 200 200 -button left -down
+vmousebutton 201 200 -button left -up
+if { [vreadpixel 100 200 -rgb -name] == "BLACK" } { puts "Error: wrong transformation" }
+
+vdump $::imagedir/${::casename}_top.png
+
+vbottom
+vfit
+vmousebutton 200 200 -button left -down
+vmousebutton 201 200 -button left -up
+if { [vreadpixel 100 200 -rgb -name] == "BLACK" } { puts "Error: wrong transformation" }
+
+vdump $::imagedir/${::casename}_bottom.png


### PR DESCRIPTION
Fix AIS_ViewCube rotation instability by replacing Euler angles with quaternions

Replace the problematic Euler angle-based rotation handling in AIS_ViewController
with a mathematically robust quaternion approach to eliminate unexpected PI/2
rotations when transitioning from view cube
orientations to mouse gestures.

Key improvements:
- Add myRotateStartQuaternion member to store camera orientation as quaternion
- Replace unstable Euler angle calculations with direct quaternion operations
- Eliminate gimbal lock singularities that occurred at pitch +-90°
- Maintain numerical stability across all camera orientations
- Remove arbitrary coordinate system transformations and magic number workarounds

The quaternion-based approach ensures smooth,
predictable camera behavior
regardless of the initial orientation set by the view
 cube, resolving the
core mathematical instability that caused erratic
rotations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a viewer command to emulate mouse button press/release at specific screen positions for automated interactions.

- Bug Fixes
  - Improved camera rotation stability and accuracy using quaternion-based orientation handling.
  - Fixed unintended movement when switching between top and bottom views with the view cube.

- Refactor
  - Pixmap export flag changed from numeric to boolean for clearer behavior.

- Tests
  - Added a regression test that simulates drags, verifies pixel output, and saves screenshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->