### PR TITLE
Foundation Classes, Strings - add EmptyString() for Ascii/Extended an…

### DIFF
--- a/src/ApplicationFramework/TKLCAF/TDF/TDF_DerivedAttribute.cxx
+++ b/src/ApplicationFramework/TKLCAF/TDF/TDF_DerivedAttribute.cxx
@@ -150,8 +150,7 @@ const TCollection_AsciiString& TDF_DerivedAttribute::TypeName(Standard_CString t
     return **aResult;
   }
 
-  static const TCollection_AsciiString anEmpty;
-  return anEmpty;
+  return TCollection_AsciiString::EmptyString();
 }
 
 //=================================================================================================

--- a/src/ApplicationFramework/TKLCAF/TDataStd/TDataStd_ExtStringArray.cxx
+++ b/src/ApplicationFramework/TKLCAF/TDataStd/TDataStd_ExtStringArray.cxx
@@ -125,8 +125,7 @@ const TCollection_ExtendedString& TDataStd_ExtStringArray::Value(const Standard_
 {
   if (myValue.IsNull())
   {
-    static TCollection_ExtendedString staticEmptyValue;
-    return staticEmptyValue;
+    return TCollection_ExtendedString::EmptyString();
   }
   return myValue->Value(index);
 }

--- a/src/ApplicationFramework/TKStdL/StdLPersistent/StdLPersistent_Collection.cxx
+++ b/src/ApplicationFramework/TKStdL/StdLPersistent/StdLPersistent_Collection.cxx
@@ -50,12 +50,11 @@ struct StdLPersistent_Collection::stringConverter
 
   const TCollection_ExtendedString& operator()(const Handle(StdObjMgt_Persistent)& theValue) const
   {
-    static TCollection_ExtendedString anEmptyString;
     if (theValue.IsNull())
-      return anEmptyString;
+      return TCollection_ExtendedString::EmptyString();
 
     Handle(TCollection_HExtendedString) aString = theValue->ExtString();
-    return aString ? aString->String() : anEmptyString;
+    return aString ? aString->String() : TCollection_ExtendedString::EmptyString();
   }
 };
 

--- a/src/ApplicationFramework/TKStdL/StdLPersistent/StdLPersistent_NamedData.cxx
+++ b/src/ApplicationFramework/TKStdL/StdLPersistent/StdLPersistent_NamedData.cxx
@@ -25,8 +25,7 @@ static const TCollection_ExtendedString& String(Handle(StdObjMgt_Persistent) the
   if (theValue)
     return theValue->ExtString()->String();
 
-  static TCollection_ExtendedString anEmptyString;
-  return anEmptyString;
+  return TCollection_ExtendedString::EmptyString();
 }
 
 template <class HArray>

--- a/src/DataExchange/TKDESTEP/RWHeaderSection/RWHeaderSection_ReadWriteModule.cxx
+++ b/src/DataExchange/TKDESTEP/RWHeaderSection/RWHeaderSection_ReadWriteModule.cxx
@@ -32,7 +32,7 @@
 IMPLEMENT_STANDARD_RTTIEXT(RWHeaderSection_ReadWriteModule, StepData_ReadWriteModule)
 
 // -- General Declarations (Recognize, StepType) ---
-static TCollection_AsciiString PasReco(""); // neutralise StartEntity de SW
+// neutralise StartEntity de SW
 static TCollection_AsciiString Reco_FileName("FILE_NAME");
 static TCollection_AsciiString Reco_FileDescription("FILE_DESCRIPTION");
 static TCollection_AsciiString Reco_FileSchema("FILE_SCHEMA");
@@ -98,7 +98,7 @@ const TCollection_AsciiString& RWHeaderSection_ReadWriteModule::StepType(
     case 3:
       return Reco_FileSchema;
     default:
-      return PasReco;
+      return TCollection_AsciiString::EmptyString();
   }
 }
 

--- a/src/DataExchange/TKDESTEP/StepData/StepData_EnumTool.cxx
+++ b/src/DataExchange/TKDESTEP/StepData/StepData_EnumTool.cxx
@@ -14,8 +14,6 @@
 #include <StepData_EnumTool.hxx>
 #include <TCollection_AsciiString.hxx>
 
-static TCollection_AsciiString nulstr("");
-
 StepData_EnumTool::StepData_EnumTool(const Standard_CString e0,
                                      const Standard_CString e1,
                                      const Standard_CString e2,
@@ -176,7 +174,7 @@ Standard_Integer StepData_EnumTool::NullValue() const
 const TCollection_AsciiString& StepData_EnumTool::Text(const Standard_Integer num) const
 {
   if (num < 0 || num >= thetexts.Length())
-    return nulstr;
+    return TCollection_AsciiString::EmptyString();
   return thetexts.Value(num + 1);
 }
 

--- a/src/DataExchange/TKRWMesh/RWMesh/RWMesh_CafReader.cxx
+++ b/src/DataExchange/TKRWMesh/RWMesh/RWMesh_CafReader.cxx
@@ -506,7 +506,10 @@ Standard_Boolean RWMesh_CafReader::addSubShapeIntoDoc(CafDocumentTools&   theToo
   theTools.ShapeTool->GetReferredShape(aNewLabel, aNewRefLabel);
 
   // put attributes to the Product (shared across Instances)
-  setShapeName(aNewRefLabel, aShapeType, aShapeAttribs.Name, TDF_Label(),
+  setShapeName(aNewRefLabel,
+               aShapeType,
+               aShapeAttribs.Name,
+               TDF_Label(),
                TCollection_AsciiString::EmptyString());
   setShapeStyle(theTools, aNewRefLabel, aShapeAttribs.Style);
   setShapeNamedData(theTools, aNewRefLabel, aShapeAttribs.NamedData);

--- a/src/DataExchange/TKRWMesh/RWMesh/RWMesh_CafReader.cxx
+++ b/src/DataExchange/TKRWMesh/RWMesh/RWMesh_CafReader.cxx
@@ -506,8 +506,8 @@ Standard_Boolean RWMesh_CafReader::addSubShapeIntoDoc(CafDocumentTools&   theToo
   theTools.ShapeTool->GetReferredShape(aNewLabel, aNewRefLabel);
 
   // put attributes to the Product (shared across Instances)
-  static const TCollection_AsciiString anEmptyString;
-  setShapeName(aNewRefLabel, aShapeType, aShapeAttribs.Name, TDF_Label(), anEmptyString);
+  setShapeName(aNewRefLabel, aShapeType, aShapeAttribs.Name, TDF_Label(),
+               TCollection_AsciiString::EmptyString());
   setShapeStyle(theTools, aNewRefLabel, aShapeAttribs.Style);
   setShapeNamedData(theTools, aNewRefLabel, aShapeAttribs.NamedData);
 

--- a/src/DataExchange/TKXCAF/XCAFPrs/XCAFPrs_DocumentExplorer.cxx
+++ b/src/DataExchange/TKXCAF/XCAFPrs/XCAFPrs_DocumentExplorer.cxx
@@ -303,7 +303,7 @@ void XCAFPrs_DocumentExplorer::initCurrent(Standard_Boolean theIsAssembly)
     myCurrent.Location  = myCurrent.LocalTrsf;
     myCurrent.Style =
       mergedStyle(myColorTool, myVisMatTool, myDefStyle, myCurrent.Label, myCurrent.RefLabel);
-    myCurrent.Id = DefineChildId(myCurrent.Label, TCollection_AsciiString());
+    myCurrent.Id = DefineChildId(myCurrent.Label, TCollection_AsciiString::EmptyString());
   }
   else
   {
@@ -356,7 +356,7 @@ void XCAFPrs_DocumentExplorer::Next()
     aNodeInStack.Location   = aNodeInStack.LocalTrsf;
     aNodeInStack.Style =
       mergedStyle(myColorTool, myVisMatTool, myDefStyle, aNodeInStack.Label, aNodeInStack.RefLabel);
-    aNodeInStack.Id = DefineChildId(aNodeInStack.Label, TCollection_AsciiString());
+    aNodeInStack.Id = DefineChildId(aNodeInStack.Label, TCollection_AsciiString::EmptyString());
     myNodeStack.SetValue(0, aNodeInStack);
     if ((myFlags & XCAFPrs_DocumentExplorerFlags_OnlyLeafNodes) == 0)
     {

--- a/src/DataExchange/TKXSBase/IFSelect/IFSelect_SessionPilot.cxx
+++ b/src/DataExchange/TKXSBase/IFSelect/IFSelect_SessionPilot.cxx
@@ -32,7 +32,6 @@ IMPLEMENT_STANDARD_RTTIEXT(IFSelect_SessionPilot, IFSelect_Activator)
 #define MAXCARS 1000
 
 static int                     THE_IFSelect_SessionPilot_initactor = 0;
-static TCollection_AsciiString nulword;
 
 // #define DEBUG_TRACE
 
@@ -217,7 +216,7 @@ const TCollection_AsciiString& IFSelect_SessionPilot::Word(const Standard_Intege
 {
   if (num < thenbwords)
     return thewords(num);
-  return nulword;
+  return TCollection_AsciiString::EmptyString();
 }
 
 Standard_CString IFSelect_SessionPilot::Arg(const Standard_Integer num) const

--- a/src/DataExchange/TKXSBase/IFSelect/IFSelect_SessionPilot.cxx
+++ b/src/DataExchange/TKXSBase/IFSelect/IFSelect_SessionPilot.cxx
@@ -31,7 +31,7 @@ IMPLEMENT_STANDARD_RTTIEXT(IFSelect_SessionPilot, IFSelect_Activator)
 #define MAXWORDS 200
 #define MAXCARS 1000
 
-static int                     THE_IFSelect_SessionPilot_initactor = 0;
+static int THE_IFSelect_SessionPilot_initactor = 0;
 
 // #define DEBUG_TRACE
 

--- a/src/DataExchange/TKXSBase/MoniTool/MoniTool_CaseData.cxx
+++ b/src/DataExchange/TKXSBase/MoniTool/MoniTool_CaseData.cxx
@@ -299,16 +299,10 @@ Standard_Integer MoniTool_CaseData::Kind(const Standard_Integer nd) const
   return thekind(nd);
 }
 
-static const TCollection_AsciiString& nulname()
-{
-  static TCollection_AsciiString nuln;
-  return nuln;
-}
-
 const TCollection_AsciiString& MoniTool_CaseData::Name(const Standard_Integer nd) const
 {
   if (nd < 1 || nd > thednam.Length())
-    return nulname();
+    return TCollection_AsciiString::EmptyString();
   return thednam(nd);
 }
 

--- a/src/Draw/TKQADraw/QABugs/QABugs_19.cxx
+++ b/src/Draw/TKQADraw/QABugs/QABugs_19.cxx
@@ -880,7 +880,7 @@ static Standard_Integer OCC11758(Draw_Interpretor& di, Standard_Integer n, const
     // assert( d.IsDifferent( a ));
     // assert( d.IsDifferent( h ));
     // assert( !d.IsDifferent( d ));
-    QCOMPARE(d.IsDifferent(TCollection_AsciiString()), Standard_True);
+    QCOMPARE(d.IsDifferent(TCollection_AsciiString::EmptyString()), Standard_True);
     QCOMPARE(d.IsDifferent(a), Standard_True);
     QCOMPARE(d.IsDifferent(h), Standard_True);
     QCOMPARE(!d.IsDifferent(d), Standard_True);

--- a/src/FoundationClasses/TKernel/Message/Message_Attribute.hxx
+++ b/src/FoundationClasses/TKernel/Message/Message_Attribute.hxx
@@ -28,7 +28,7 @@ class Message_Attribute : public Standard_Transient
 public:
   //! Empty constructor
   Standard_EXPORT Message_Attribute(
-    const TCollection_AsciiString& theName = TCollection_AsciiString());
+    const TCollection_AsciiString& theName = TCollection_AsciiString::EmptyString());
 
   //! Return a C string to be used as a key for generating text user messages describing this alert.
   //! The messages are generated with help of Message_Msg class, in Message_Report::Dump().

--- a/src/FoundationClasses/TKernel/Message/Message_AttributeMeter.hxx
+++ b/src/FoundationClasses/TKernel/Message/Message_AttributeMeter.hxx
@@ -16,6 +16,7 @@
 
 #include <Message_Attribute.hxx>
 #include <Message_MetricType.hxx>
+#include <TCollection_AsciiString.hxx>
 
 #include <NCollection_IndexedDataMap.hxx>
 

--- a/src/FoundationClasses/TKernel/Message/Message_AttributeMeter.hxx
+++ b/src/FoundationClasses/TKernel/Message/Message_AttributeMeter.hxx
@@ -33,7 +33,7 @@ public:
 public:
   //! Constructor with string argument
   Standard_EXPORT Message_AttributeMeter(
-    const TCollection_AsciiString& theName = TCollection_AsciiString());
+    const TCollection_AsciiString& theName = TCollection_AsciiString::EmptyString());
 
   //! Checks whether the attribute has values for the metric
   //! @param[in] theMetric  metric type

--- a/src/FoundationClasses/TKernel/Message/Message_AttributeObject.hxx
+++ b/src/FoundationClasses/TKernel/Message/Message_AttributeObject.hxx
@@ -25,7 +25,7 @@ public:
   //! Constructor with string argument
   Standard_EXPORT Message_AttributeObject(
     const Handle(Standard_Transient)& theObject,
-    const TCollection_AsciiString&    theName = TCollection_AsciiString());
+    const TCollection_AsciiString&    theName = TCollection_AsciiString::EmptyString());
 
   //! Returns object
   //! @return the object instance

--- a/src/FoundationClasses/TKernel/Message/Message_AttributeObject.hxx
+++ b/src/FoundationClasses/TKernel/Message/Message_AttributeObject.hxx
@@ -15,6 +15,7 @@
 #define _Message_AttributeObject_HeaderFile
 
 #include <Message_Attribute.hxx>
+#include <TCollection_AsciiString.hxx>
 #include <NCollection_DefineAlloc.hxx>
 
 //! Alert object storing a transient object

--- a/src/FoundationClasses/TKernel/Message/Message_AttributeStream.hxx
+++ b/src/FoundationClasses/TKernel/Message/Message_AttributeStream.hxx
@@ -15,6 +15,7 @@
 #define _Message_AttributeStream_HeaderFile
 
 #include <Message_Attribute.hxx>
+#include <TCollection_AsciiString.hxx>
 
 #include <Standard_SStream.hxx>
 

--- a/src/FoundationClasses/TKernel/Message/Message_AttributeStream.hxx
+++ b/src/FoundationClasses/TKernel/Message/Message_AttributeStream.hxx
@@ -26,7 +26,7 @@ public:
   //! Constructor with string argument
   Standard_EXPORT Message_AttributeStream(
     const Standard_SStream&        theStream,
-    const TCollection_AsciiString& theName = TCollection_AsciiString());
+    const TCollection_AsciiString& theName = TCollection_AsciiString::EmptyString());
 
   //! Returns stream value
   const Standard_SStream& Stream() const { return myStream; }

--- a/src/FoundationClasses/TKernel/Message/Message_Level.hxx
+++ b/src/FoundationClasses/TKernel/Message/Message_Level.hxx
@@ -40,7 +40,7 @@ public:
   //! Constructor.
   //! One string key is used for all alert meters.
   //! The perf meter is not started automatically, it will be done in AddAlert() method
-  Standard_EXPORT Message_Level(const TCollection_AsciiString& theName = TCollection_AsciiString());
+  Standard_EXPORT Message_Level(const TCollection_AsciiString& theName = TCollection_AsciiString::EmptyString());
 
   //! Assures stopping upon destruction
   Standard_EXPORT ~Message_Level();

--- a/src/FoundationClasses/TKernel/Message/Message_Level.hxx
+++ b/src/FoundationClasses/TKernel/Message/Message_Level.hxx
@@ -41,7 +41,8 @@ public:
   //! Constructor.
   //! One string key is used for all alert meters.
   //! The perf meter is not started automatically, it will be done in AddAlert() method
-  Standard_EXPORT Message_Level(const TCollection_AsciiString& theName = TCollection_AsciiString::EmptyString());
+  Standard_EXPORT Message_Level(
+    const TCollection_AsciiString& theName = TCollection_AsciiString::EmptyString());
 
   //! Assures stopping upon destruction
   Standard_EXPORT ~Message_Level();

--- a/src/FoundationClasses/TKernel/Message/Message_Level.hxx
+++ b/src/FoundationClasses/TKernel/Message/Message_Level.hxx
@@ -18,6 +18,7 @@
 #include <Message_AlertExtended.hxx>
 #include <Message_Gravity.hxx>
 #include <Message_Messenger.hxx>
+#include <TCollection_AsciiString.hxx>
 
 #include <Standard.hxx>
 

--- a/src/FoundationClasses/TKernel/TCollection/TCollection_AsciiString.cxx
+++ b/src/FoundationClasses/TKernel/TCollection/TCollection_AsciiString.cxx
@@ -1272,7 +1272,7 @@ Standard_Boolean TCollection_AsciiString::IsSameString(const Standard_CString th
 
 //=================================================================================================
 
-const TCollection_AsciiString& TCollection_AsciiString::EmptyString()
+const TCollection_AsciiString& TCollection_AsciiString::EmptyString() noexcept
 {
   static const TCollection_AsciiString THE_EMPTY_STRING;
   return THE_EMPTY_STRING;

--- a/src/FoundationClasses/TKernel/TCollection/TCollection_AsciiString.cxx
+++ b/src/FoundationClasses/TKernel/TCollection/TCollection_AsciiString.cxx
@@ -61,7 +61,7 @@ struct FormattedReal
 
 //=================================================================================================
 
-TCollection_AsciiString::TCollection_AsciiString()
+TCollection_AsciiString::TCollection_AsciiString() noexcept
 {
   allocate(0);
 }

--- a/src/FoundationClasses/TKernel/TCollection/TCollection_AsciiString.cxx
+++ b/src/FoundationClasses/TKernel/TCollection/TCollection_AsciiString.cxx
@@ -1269,3 +1269,11 @@ Standard_Boolean TCollection_AsciiString::IsSameString(const Standard_CString th
     return Standard_True;
   }
 }
+
+//=================================================================================================
+
+const TCollection_AsciiString& TCollection_AsciiString::EmptyString()
+{
+  static const TCollection_AsciiString THE_EMPTY_STRING;
+  return THE_EMPTY_STRING;
+}

--- a/src/FoundationClasses/TKernel/TCollection/TCollection_AsciiString.hxx
+++ b/src/FoundationClasses/TKernel/TCollection/TCollection_AsciiString.hxx
@@ -1362,6 +1362,18 @@ public:
   //! @return a computed hash code
   inline size_t HashCode() const;
 
+  //! Returns a const reference to a single shared empty string instance.
+  //! This method provides access to a static empty string to avoid creating temporary empty strings.
+  //! Use this method instead of constructing empty strings when you need a const reference.
+  //!
+  //! Example:
+  //! ```cpp
+  //! const TCollection_AsciiString& anEmptyStr = TCollection_AsciiString::EmptyString();
+  //! // Use anEmptyStr instead of TCollection_AsciiString()
+  //! ```
+  //! @return const reference to static empty string
+  Standard_EXPORT static const TCollection_AsciiString& EmptyString();
+
   //! Returns True  when the two  strings are the same.
   //! (Just for HashCode for AsciiString)
   //! @param[in] string1 first string to compare

--- a/src/FoundationClasses/TKernel/TCollection/TCollection_AsciiString.hxx
+++ b/src/FoundationClasses/TKernel/TCollection/TCollection_AsciiString.hxx
@@ -1372,7 +1372,7 @@ public:
   //! // Use anEmptyStr instead of TCollection_AsciiString()
   //! ```
   //! @return const reference to static empty string
-  Standard_EXPORT static const TCollection_AsciiString& EmptyString();
+  Standard_EXPORT static const TCollection_AsciiString& EmptyString() noexcept;
 
   //! Returns True  when the two  strings are the same.
   //! (Just for HashCode for AsciiString)

--- a/src/FoundationClasses/TKernel/TCollection/TCollection_AsciiString.hxx
+++ b/src/FoundationClasses/TKernel/TCollection/TCollection_AsciiString.hxx
@@ -1363,8 +1363,9 @@ public:
   inline size_t HashCode() const;
 
   //! Returns a const reference to a single shared empty string instance.
-  //! This method provides access to a static empty string to avoid creating temporary empty strings.
-  //! Use this method instead of constructing empty strings when you need a const reference.
+  //! This method provides access to a static empty string to avoid creating temporary empty
+  //! strings. Use this method instead of constructing empty strings when you need a const
+  //! reference.
   //!
   //! Example:
   //! ```cpp

--- a/src/FoundationClasses/TKernel/TCollection/TCollection_AsciiString.hxx
+++ b/src/FoundationClasses/TKernel/TCollection/TCollection_AsciiString.hxx
@@ -55,7 +55,7 @@ public:
   DEFINE_STANDARD_ALLOC
 
   //! Initializes a AsciiString to an empty AsciiString.
-  Standard_EXPORT TCollection_AsciiString();
+  Standard_EXPORT TCollection_AsciiString() noexcept;
 
 #if Standard_CPP17_OR_HIGHER
   //! Initializes a AsciiString with a string_view.

--- a/src/FoundationClasses/TKernel/TCollection/TCollection_ExtendedString.cxx
+++ b/src/FoundationClasses/TKernel/TCollection/TCollection_ExtendedString.cxx
@@ -94,7 +94,7 @@ inline Standard_ExtCharacter* Standard_UNUSED
 
 //=================================================================================================
 
-TCollection_ExtendedString::TCollection_ExtendedString()
+TCollection_ExtendedString::TCollection_ExtendedString() noexcept
 {
   allocate(0);
 }

--- a/src/FoundationClasses/TKernel/TCollection/TCollection_ExtendedString.cxx
+++ b/src/FoundationClasses/TKernel/TCollection/TCollection_ExtendedString.cxx
@@ -950,3 +950,11 @@ void TCollection_ExtendedString::deallocate()
   mylength = 0;
   mystring = THE_DEFAULT_EXT_CHAR_STRING;
 }
+
+//=================================================================================================
+
+const TCollection_ExtendedString& TCollection_ExtendedString::EmptyString()
+{
+  static const TCollection_ExtendedString THE_EMPTY_STRING;
+  return THE_EMPTY_STRING;
+}

--- a/src/FoundationClasses/TKernel/TCollection/TCollection_ExtendedString.cxx
+++ b/src/FoundationClasses/TKernel/TCollection/TCollection_ExtendedString.cxx
@@ -953,7 +953,7 @@ void TCollection_ExtendedString::deallocate()
 
 //=================================================================================================
 
-const TCollection_ExtendedString& TCollection_ExtendedString::EmptyString()
+const TCollection_ExtendedString& TCollection_ExtendedString::EmptyString() noexcept
 {
   static const TCollection_ExtendedString THE_EMPTY_STRING;
   return THE_EMPTY_STRING;

--- a/src/FoundationClasses/TKernel/TCollection/TCollection_ExtendedString.hxx
+++ b/src/FoundationClasses/TKernel/TCollection/TCollection_ExtendedString.hxx
@@ -350,6 +350,18 @@ public:
     return opencascade::hashBytes(mystring, aSize);
   }
 
+  //! Returns a const reference to a single shared empty string instance.
+  //! This method provides access to a static empty string to avoid creating temporary empty strings.
+  //! Use this method instead of constructing empty strings when you need a const reference.
+  //!
+  //! Example:
+  //! ```cpp
+  //! const TCollection_ExtendedString& anEmptyStr = TCollection_ExtendedString::EmptyString();
+  //! // Use anEmptyStr instead of TCollection_ExtendedString()
+  //! ```
+  //! @return const reference to static empty string
+  Standard_EXPORT static const TCollection_ExtendedString& EmptyString();
+
   //! Returns true if the characters in this extended
   //! string are identical to the characters in the other extended string.
   //! Note that this method is an alias of operator ==.

--- a/src/FoundationClasses/TKernel/TCollection/TCollection_ExtendedString.hxx
+++ b/src/FoundationClasses/TKernel/TCollection/TCollection_ExtendedString.hxx
@@ -360,7 +360,7 @@ public:
   //! // Use anEmptyStr instead of TCollection_ExtendedString()
   //! ```
   //! @return const reference to static empty string
-  Standard_EXPORT static const TCollection_ExtendedString& EmptyString();
+  Standard_EXPORT static const TCollection_ExtendedString& EmptyString() noexcept;
 
   //! Returns true if the characters in this extended
   //! string are identical to the characters in the other extended string.

--- a/src/FoundationClasses/TKernel/TCollection/TCollection_ExtendedString.hxx
+++ b/src/FoundationClasses/TKernel/TCollection/TCollection_ExtendedString.hxx
@@ -54,7 +54,7 @@ public:
   DEFINE_STANDARD_ALLOC
 
   //! Initializes a ExtendedString to an empty ExtendedString.
-  Standard_EXPORT TCollection_ExtendedString();
+  Standard_EXPORT TCollection_ExtendedString() noexcept;
 
   //! Creation by converting a CString to an extended
   //! string.  If <isMultiByte> is true then the string is

--- a/src/FoundationClasses/TKernel/TCollection/TCollection_ExtendedString.hxx
+++ b/src/FoundationClasses/TKernel/TCollection/TCollection_ExtendedString.hxx
@@ -351,8 +351,9 @@ public:
   }
 
   //! Returns a const reference to a single shared empty string instance.
-  //! This method provides access to a static empty string to avoid creating temporary empty strings.
-  //! Use this method instead of constructing empty strings when you need a const reference.
+  //! This method provides access to a static empty string to avoid creating temporary empty
+  //! strings. Use this method instead of constructing empty strings when you need a const
+  //! reference.
   //!
   //! Example:
   //! ```cpp

--- a/src/ModelingData/TKBRep/TopoDS/TopoDS_AlertAttribute.hxx
+++ b/src/ModelingData/TKBRep/TopoDS/TopoDS_AlertAttribute.hxx
@@ -32,7 +32,7 @@ public:
   //! Constructor with shape argument
   Standard_EXPORT TopoDS_AlertAttribute(
     const TopoDS_Shape&            theShape,
-    const TCollection_AsciiString& theName = TCollection_AsciiString());
+    const TCollection_AsciiString& theName = TCollection_AsciiString::EmptyString());
 
   //! Returns contained shape
   const TopoDS_Shape& GetShape() const { return myShape; }

--- a/src/ModelingData/TKBRep/TopoDS/TopoDS_AlertAttribute.hxx
+++ b/src/ModelingData/TKBRep/TopoDS/TopoDS_AlertAttribute.hxx
@@ -19,6 +19,7 @@
 #include <Message_AttributeStream.hxx>
 #include <Message_Messenger.hxx>
 #include <Message_Report.hxx>
+#include <TCollection_AsciiString.hxx>
 
 #include <TopoDS_Shape.hxx>
 

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_AspectsProgram.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_AspectsProgram.cxx
@@ -16,11 +16,6 @@
 #include <OpenGl_ShaderManager.hxx>
 #include <OpenGl_ShaderProgram.hxx>
 
-namespace
-{
-static const TCollection_AsciiString THE_EMPTY_KEY;
-}
-
 //=================================================================================================
 
 void OpenGl_AspectsProgram::Release(OpenGl_Context* theCtx)
@@ -37,8 +32,9 @@ void OpenGl_AspectsProgram::Release(OpenGl_Context* theCtx)
 
 void OpenGl_AspectsProgram::UpdateRediness(const Handle(Graphic3d_Aspects)& theAspect)
 {
-  const TCollection_AsciiString& aShaderKey =
-    theAspect->ShaderProgram().IsNull() ? THE_EMPTY_KEY : theAspect->ShaderProgram()->GetId();
+  const TCollection_AsciiString& aShaderKey = theAspect->ShaderProgram().IsNull()
+                                                ? TCollection_AsciiString::EmptyString()
+                                                : theAspect->ShaderProgram()->GetId();
   if (aShaderKey.IsEmpty() || myShaderProgramId != aShaderKey)
   {
     myIsShaderReady = Standard_False;

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_AspectsSprite.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_AspectsSprite.cxx
@@ -21,11 +21,6 @@
 #include <Graphic3d_MarkerImage.hxx>
 #include <TColStd_HArray1OfByte.hxx>
 
-namespace
-{
-static const TCollection_AsciiString THE_EMPTY_KEY;
-}
-
 //=================================================================================================
 
 void OpenGl_AspectsSprite::Release(OpenGl_Context* theCtx)
@@ -98,9 +93,9 @@ void OpenGl_AspectsSprite::UpdateRediness(const Handle(Graphic3d_Aspects)& theAs
              aSpriteKeyNew,
              aSpriteAKeyNew);
   const TCollection_AsciiString& aSpriteKeyOld =
-    !mySprite.IsNull() ? mySprite->ResourceId() : THE_EMPTY_KEY;
+    !mySprite.IsNull() ? mySprite->ResourceId() : TCollection_AsciiString::EmptyString();
   const TCollection_AsciiString& aSpriteAKeyOld =
-    !mySpriteA.IsNull() ? mySpriteA->ResourceId() : THE_EMPTY_KEY;
+    !mySpriteA.IsNull() ? mySpriteA->ResourceId() : TCollection_AsciiString::EmptyString();
   if (aSpriteKeyNew.IsEmpty() || aSpriteKeyOld != aSpriteKeyNew || aSpriteAKeyNew.IsEmpty()
       || aSpriteAKeyOld != aSpriteAKeyNew)
   {
@@ -143,9 +138,9 @@ void OpenGl_AspectsSprite::build(const Handle(OpenGl_Context)&        theCtx,
   spriteKeys(theMarkerImage, theType, theScale, theColor, aNewKey, aNewKeyA);
 
   const TCollection_AsciiString& aSpriteKeyOld =
-    !mySprite.IsNull() ? mySprite->ResourceId() : THE_EMPTY_KEY;
+    !mySprite.IsNull() ? mySprite->ResourceId() : TCollection_AsciiString::EmptyString();
   const TCollection_AsciiString& aSpriteAKeyOld =
-    !mySpriteA.IsNull() ? mySpriteA->ResourceId() : THE_EMPTY_KEY;
+    !mySpriteA.IsNull() ? mySpriteA->ResourceId() : TCollection_AsciiString::EmptyString();
 
   // release old shared resources
   const Standard_Boolean aNewResource = aNewKey.IsEmpty() || aSpriteKeyOld != aNewKey;

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_AspectsTextureSet.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_AspectsTextureSet.cxx
@@ -19,11 +19,6 @@
 
 #include <Graphic3d_TextureParams.hxx>
 
-namespace
-{
-static const TCollection_AsciiString THE_EMPTY_KEY;
-}
-
 //=================================================================================================
 
 void OpenGl_AspectsTextureSet::Release(OpenGl_Context* theCtx)

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_FrameBuffer.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_FrameBuffer.hxx
@@ -55,7 +55,7 @@ public:
 public:
   //! Empty constructor
   Standard_EXPORT OpenGl_FrameBuffer(
-    const TCollection_AsciiString& theResourceId = TCollection_AsciiString());
+    const TCollection_AsciiString& theResourceId = TCollection_AsciiString::EmptyString());
 
   //! Destructor
   Standard_EXPORT virtual ~OpenGl_FrameBuffer();

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_FrameBuffer.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_FrameBuffer.hxx
@@ -16,7 +16,7 @@
 #define OpenGl_FrameBuffer_HeaderFile
 
 #include <OpenGl_NamedResource.hxx>
-
+#include <TCollection_AsciiString.hxx>
 #include <Graphic3d_BufferType.hxx>
 #include <Graphic3d_Vec2.hxx>
 #include <NCollection_Vector.hxx>

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_Texture.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_Texture.hxx
@@ -22,6 +22,7 @@
 #include <OpenGl_Sampler.hxx>
 #include <Graphic3d_TextureUnit.hxx>
 #include <Graphic3d_TypeOfTexture.hxx>
+#include <TCollection_AsciiString.hxx>
 
 //! Texture resource.
 class OpenGl_Texture : public OpenGl_NamedResource

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_Texture.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_Texture.hxx
@@ -39,7 +39,7 @@ public:
 public:
   //! Create uninitialized texture.
   Standard_EXPORT OpenGl_Texture(
-    const TCollection_AsciiString&         theResourceId = TCollection_AsciiString(),
+    const TCollection_AsciiString&         theResourceId = TCollection_AsciiString::EmptyString(),
     const Handle(Graphic3d_TextureParams)& theParams     = Handle(Graphic3d_TextureParams)());
 
   //! Destroy object.

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.hxx
@@ -673,9 +673,6 @@ protected: //! @name data types related to ray-tracing
   class ShaderSource
   {
   public:
-    //! Default shader prefix - empty string.
-    static const TCollection_AsciiString EMPTY_PREFIX;
-
     //! Creates new uninitialized shader source.
     ShaderSource()
     {
@@ -698,11 +695,11 @@ protected: //! @name data types related to ray-tracing
 
     //! Loads shader source from specified files.
     Standard_Boolean LoadFromFiles(const TCollection_AsciiString* theFileNames,
-                                   const TCollection_AsciiString& thePrefix = EMPTY_PREFIX);
+                                   const TCollection_AsciiString& thePrefix = TCollection_AsciiString::EmptyString());
 
     //! Loads shader source from specified strings.
     Standard_Boolean LoadFromStrings(const TCollection_AsciiString* theStrings,
-                                     const TCollection_AsciiString& thePrefix = EMPTY_PREFIX);
+                                     const TCollection_AsciiString& thePrefix = TCollection_AsciiString::EmptyString());
 
   private:
     TCollection_AsciiString mySource; //!< Source string of the shader object

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.hxx
@@ -27,6 +27,7 @@
 #include <OpenGl_SceneGeometry.hxx>
 #include <OpenGl_Structure.hxx>
 #include <OpenGl_TileSampler.hxx>
+#include <TCollection_AsciiString.hxx>
 
 #include <map>
 #include <set>

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.hxx
@@ -695,12 +695,14 @@ protected: //! @name data types related to ray-tracing
                                    const GLenum                  theType) const;
 
     //! Loads shader source from specified files.
-    Standard_Boolean LoadFromFiles(const TCollection_AsciiString* theFileNames,
-                                   const TCollection_AsciiString& thePrefix = TCollection_AsciiString::EmptyString());
+    Standard_Boolean LoadFromFiles(
+      const TCollection_AsciiString* theFileNames,
+      const TCollection_AsciiString& thePrefix = TCollection_AsciiString::EmptyString());
 
     //! Loads shader source from specified strings.
-    Standard_Boolean LoadFromStrings(const TCollection_AsciiString* theStrings,
-                                     const TCollection_AsciiString& thePrefix = TCollection_AsciiString::EmptyString());
+    Standard_Boolean LoadFromStrings(
+      const TCollection_AsciiString* theStrings,
+      const TCollection_AsciiString& thePrefix = TCollection_AsciiString::EmptyString());
 
   private:
     TCollection_AsciiString mySource; //!< Source string of the shader object

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_View_Raytrace.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_View_Raytrace.cxx
@@ -1062,8 +1062,6 @@ Standard_Boolean OpenGl_View::addRaytracePolygonArray(
   return Standard_True;
 }
 
-const TCollection_AsciiString OpenGl_View::ShaderSource::EMPTY_PREFIX;
-
 // =======================================================================
 // function : Source
 // purpose  : Returns shader source combined with prefix

--- a/src/Visualization/TKService/Font/Font_FontMgr.cxx
+++ b/src/Visualization/TKService/Font/Font_FontMgr.cxx
@@ -1087,7 +1087,7 @@ Handle(Font_SystemFont) Font_FontMgr::FindFont(const TCollection_AsciiString& th
   if (aFont.IsNull() && theStrictLevel == Font_StrictLevel_Any)
   {
     // try finding ANY font in case if even default fallback alias myFallbackAlias cannot be found
-    aFont = myFontMap.Find(TCollection_AsciiString());
+    aFont = myFontMap.Find(TCollection_AsciiString::EmptyString());
   }
   if (aFont.IsNull())
   {

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_AspectText3d.hxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_AspectText3d.hxx
@@ -62,8 +62,7 @@ public:
   {
     if (myTextFont.IsNull())
     {
-      static const TCollection_AsciiString anEmpty;
-      return anEmpty;
+      return TCollection_AsciiString::EmptyString();
     }
     return myTextFont->String();
   }

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderObject.hxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderObject.hxx
@@ -81,8 +81,8 @@ public:
     Graphic3d_TypeOfShaderObject   theType,
     const ShaderVariableList&      theUniforms,
     const ShaderVariableList&      theStageInOuts,
-    const TCollection_AsciiString& theInName           = TCollection_AsciiString(),
-    const TCollection_AsciiString& theOutName          = TCollection_AsciiString(),
+    const TCollection_AsciiString& theInName           = TCollection_AsciiString::EmptyString(),
+    const TCollection_AsciiString& theOutName          = TCollection_AsciiString::EmptyString(),
     Standard_Integer               theNbGeomInputVerts = 0);
 
 private:

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderObject.hxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderObject.hxx
@@ -19,6 +19,7 @@
 #include <Graphic3d_TypeOfShaderObject.hxx>
 #include <NCollection_Sequence.hxx>
 #include <OSD_Path.hxx>
+#include <TCollection_AsciiString.hxx>
 
 //! Forward declaration
 

--- a/src/Visualization/TKService/WNT/WNT_WClass.hxx
+++ b/src/Visualization/TKService/WNT/WNT_WClass.hxx
@@ -60,7 +60,7 @@ public:
     const Standard_Integer         theWindowExtra = 0,
     const Aspect_Handle            theCursor      = NULL,
     const Aspect_Handle            theIcon        = NULL,
-    const TCollection_AsciiString& theMenuName    = TCollection_AsciiString());
+    const TCollection_AsciiString& theMenuName    = TCollection_AsciiString::EmptyString());
 
   //! Destroys all resources attached to the class
   Standard_EXPORT ~WNT_WClass();

--- a/src/Visualization/TKV3d/PrsDim/PrsDim_AngleDimension.cxx
+++ b/src/Visualization/TKV3d/PrsDim/PrsDim_AngleDimension.cxx
@@ -54,9 +54,9 @@ IMPLEMENT_STANDARD_RTTIEXT(PrsDim_AngleDimension, PrsDim_Dimension)
 
 namespace
 {
-static const Standard_Real              THE_EMPTY_LABEL_WIDTH = 0.0;
-static const Standard_ExtCharacter      THE_DEGREE_SYMBOL(0x00B0);
-static const Standard_Real              THE_3D_TEXT_MARGIN = 0.1;
+static const Standard_Real         THE_EMPTY_LABEL_WIDTH = 0.0;
+static const Standard_ExtCharacter THE_DEGREE_SYMBOL(0x00B0);
+static const Standard_Real         THE_3D_TEXT_MARGIN = 0.1;
 
 //! Returns true if the given points lie on a same line.
 static Standard_Boolean isSameLine(const gp_Pnt& theFirstPoint,

--- a/src/Visualization/TKV3d/PrsDim/PrsDim_AngleDimension.cxx
+++ b/src/Visualization/TKV3d/PrsDim/PrsDim_AngleDimension.cxx
@@ -54,7 +54,6 @@ IMPLEMENT_STANDARD_RTTIEXT(PrsDim_AngleDimension, PrsDim_Dimension)
 
 namespace
 {
-static const TCollection_ExtendedString THE_EMPTY_LABEL_STRING;
 static const Standard_Real              THE_EMPTY_LABEL_WIDTH = 0.0;
 static const Standard_ExtCharacter      THE_DEGREE_SYMBOL(0x00B0);
 static const Standard_Real              THE_3D_TEXT_MARGIN = 0.1;
@@ -776,7 +775,7 @@ void PrsDim_AngleDimension::Compute(const Handle(PrsMgr_PresentationManager)&,
                     aDimensionAspect->ArrowTailSize(),
                     aFirstArrowEnd,
                     aFirstExtensionDir,
-                    THE_EMPTY_LABEL_STRING,
+                    TCollection_ExtendedString::EmptyString(),
                     THE_EMPTY_LABEL_WIDTH,
                     theMode,
                     LabelPosition_None);
@@ -789,7 +788,7 @@ void PrsDim_AngleDimension::Compute(const Handle(PrsMgr_PresentationManager)&,
                     aDimensionAspect->ArrowTailSize(),
                     aSecondArrowEnd,
                     aSecondExtensionDir,
-                    THE_EMPTY_LABEL_STRING,
+                    TCollection_ExtendedString::EmptyString(),
                     THE_EMPTY_LABEL_WIDTH,
                     theMode,
                     LabelPosition_None);

--- a/src/Visualization/TKV3d/PrsDim/PrsDim_Dimension.cxx
+++ b/src/Visualization/TKV3d/PrsDim/PrsDim_Dimension.cxx
@@ -67,10 +67,6 @@ IMPLEMENT_STANDARD_RTTIEXT(PrsDim_Dimension, AIS_InteractiveObject)
 
 namespace
 {
-// default text strings
-static const TCollection_ExtendedString THE_EMPTY_LABEL;
-static const TCollection_AsciiString    THE_UNDEFINED_UNITS;
-
 // default text margin and resolution
 static const Standard_Real THE_3D_TEXT_MARGIN = 0.1;
 
@@ -218,14 +214,14 @@ void PrsDim_Dimension::SetFlyout(const Standard_Real theFlyout)
 
 const TCollection_AsciiString& PrsDim_Dimension::GetDisplayUnits() const
 {
-  return THE_UNDEFINED_UNITS;
+  return TCollection_AsciiString::EmptyString();
 }
 
 //=================================================================================================
 
 const TCollection_AsciiString& PrsDim_Dimension::GetModelUnits() const
 {
-  return THE_UNDEFINED_UNITS;
+  return TCollection_AsciiString::EmptyString();
 }
 
 //=================================================================================================
@@ -813,7 +809,7 @@ void PrsDim_Dimension::DrawLinearDimension(const Handle(Prs3d_Presentation)& the
                         aDimensionAspect->ArrowTailSize(),
                         aFirstArrowEnd,
                         aFirstExtensionDir,
-                        THE_EMPTY_LABEL,
+                        TCollection_ExtendedString::EmptyString(),
                         0.0,
                         theMode,
                         LabelPosition_None);
@@ -823,7 +819,7 @@ void PrsDim_Dimension::DrawLinearDimension(const Handle(Prs3d_Presentation)& the
                           aDimensionAspect->ArrowTailSize(),
                           aSecondArrowEnd,
                           aSecondExtensionDir,
-                          THE_EMPTY_LABEL,
+                          TCollection_ExtendedString::EmptyString(),
                           0.0,
                           theMode,
                           LabelPosition_None);
@@ -892,7 +888,7 @@ void PrsDim_Dimension::DrawLinearDimension(const Handle(Prs3d_Presentation)& the
                         aDimensionAspect->ArrowTailSize(),
                         aSecondArrowEnd,
                         aSecondExtensionDir,
-                        THE_EMPTY_LABEL,
+                        TCollection_ExtendedString::EmptyString(),
                         0.0,
                         theMode,
                         LabelPosition_None);
@@ -958,7 +954,7 @@ void PrsDim_Dimension::DrawLinearDimension(const Handle(Prs3d_Presentation)& the
                         aDimensionAspect->ArrowTailSize(),
                         aFirstArrowEnd,
                         aFirstExtensionDir,
-                        THE_EMPTY_LABEL,
+                        TCollection_ExtendedString::EmptyString(),
                         0.0,
                         theMode,
                         LabelPosition_None);


### PR DESCRIPTION
…d use it everywhere

Introduce TCollection_AsciiString::EmptyString() and TCollection_ExtendedString::EmptyString() and update headers. Replace many local/static empty string instances and default-constructed temporaries with the shared EmptyString() reference across ApplicationFramework, DataExchange, Visualization and other modules. Remove several unused local empty-key/static variables and adjust default parameters and return paths to use the centralized empty-string accessors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `EmptyString()` static methods to `TCollection_AsciiString` and `TCollection_ExtendedString` for accessing shared empty string instances.

* **Refactor**
  * Consolidated empty string handling across the codebase by replacing internal static variables with unified library-provided empty string accessors. Updated constructor default arguments to use the new `EmptyString()` methods for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->