### PR TITLE
Foundation Classes, gp - Mark 2D geometry APIs noexcept/constexpr

### DIFF
--- a/src/FoundationClasses/TKMath/gp/gp_Ax22d.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Ax22d.cxx
@@ -26,7 +26,7 @@
 #include <gp_Vec2d.hxx>
 #include <Standard_Dump.hxx>
 
-void gp_Ax22d::Mirror(const gp_Pnt2d& P)
+void gp_Ax22d::Mirror(const gp_Pnt2d& P) noexcept
 {
   gp_Pnt2d Temp = point;
   Temp.Mirror(P);
@@ -35,14 +35,14 @@ void gp_Ax22d::Mirror(const gp_Pnt2d& P)
   vydir.Reverse();
 }
 
-gp_Ax22d gp_Ax22d::Mirrored(const gp_Pnt2d& P) const
+gp_Ax22d gp_Ax22d::Mirrored(const gp_Pnt2d& P) const noexcept
 {
   gp_Ax22d Temp = *this;
   Temp.Mirror(P);
   return Temp;
 }
 
-void gp_Ax22d::Mirror(const gp_Ax2d& A1)
+void gp_Ax22d::Mirror(const gp_Ax2d& A1) noexcept
 {
   vydir.Mirror(A1);
   vxdir.Mirror(A1);
@@ -51,7 +51,7 @@ void gp_Ax22d::Mirror(const gp_Ax2d& A1)
   point = Temp;
 }
 
-gp_Ax22d gp_Ax22d::Mirrored(const gp_Ax2d& A1) const
+gp_Ax22d gp_Ax22d::Mirrored(const gp_Ax2d& A1) const noexcept
 {
   gp_Ax22d Temp = *this;
   Temp.Mirror(A1);

--- a/src/FoundationClasses/TKMath/gp/gp_Ax22d.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Ax22d.hxx
@@ -167,7 +167,7 @@ public:
   //! Returns the "YDirection" of <me>.
   constexpr const gp_Dir2d& YDirection() const noexcept { return vydir; }
 
-  Standard_EXPORT void Mirror(const gp_Pnt2d& theP);
+  Standard_EXPORT void Mirror(const gp_Pnt2d& theP) noexcept;
 
   //! Performs the symmetrical transformation of an axis
   //! placement with respect to the point theP which is the
@@ -176,9 +176,9 @@ public:
   //! The main direction of the axis placement is not changed.
   //! The "XDirection" and the "YDirection" are reversed.
   //! So the axis placement stay right handed.
-  Standard_NODISCARD Standard_EXPORT gp_Ax22d Mirrored(const gp_Pnt2d& theP) const;
+  Standard_NODISCARD Standard_EXPORT gp_Ax22d Mirrored(const gp_Pnt2d& theP) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax2d& theA);
+  Standard_EXPORT void Mirror(const gp_Ax2d& theA) noexcept;
 
   //! Performs the symmetrical transformation of an axis
   //! placement with respect to an axis placement which
@@ -187,7 +187,7 @@ public:
   //! point, on the "XDirection" and "YDirection".
   //! The resulting main "Direction" is the cross product between
   //! the "XDirection" and the "YDirection" after transformation.
-  Standard_NODISCARD Standard_EXPORT gp_Ax22d Mirrored(const gp_Ax2d& theA) const;
+  Standard_NODISCARD Standard_EXPORT gp_Ax22d Mirrored(const gp_Ax2d& theA) const noexcept;
 
   void Rotate(const gp_Pnt2d& theP, const Standard_Real theAng);
 
@@ -217,7 +217,7 @@ public:
     return aTemp;
   }
 
-  void Transform(const gp_Trsf2d& theT);
+  void Transform(const gp_Trsf2d& theT) noexcept;
 
   //! Transforms an axis placement with a Trsf.
   //! The "Location" point, the "XDirection" and the
@@ -358,7 +358,7 @@ inline void gp_Ax22d::Scale(const gp_Pnt2d& theP, const Standard_Real theS)
 
 //=================================================================================================
 
-inline void gp_Ax22d::Transform(const gp_Trsf2d& theT)
+inline void gp_Ax22d::Transform(const gp_Trsf2d& theT) noexcept
 {
   gp_Pnt2d aTemp = point;
   aTemp.Transform(theT);

--- a/src/FoundationClasses/TKMath/gp/gp_Ax2d.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Ax2d.cxx
@@ -51,26 +51,26 @@ void gp_Ax2d::Scale(const gp_Pnt2d& P, const Standard_Real S)
     vdir.Reverse();
 }
 
-void gp_Ax2d::Mirror(const gp_Pnt2d& P)
+void gp_Ax2d::Mirror(const gp_Pnt2d& P) noexcept
 {
   loc.Mirror(P);
   vdir.Reverse();
 }
 
-gp_Ax2d gp_Ax2d::Mirrored(const gp_Pnt2d& P) const
+gp_Ax2d gp_Ax2d::Mirrored(const gp_Pnt2d& P) const noexcept
 {
   gp_Ax2d A = *this;
   A.Mirror(P);
   return A;
 }
 
-void gp_Ax2d::Mirror(const gp_Ax2d& A)
+void gp_Ax2d::Mirror(const gp_Ax2d& A) noexcept
 {
   loc.Mirror(A);
   vdir.Mirror(A.vdir);
 }
 
-gp_Ax2d gp_Ax2d::Mirrored(const gp_Ax2d& A) const
+gp_Ax2d gp_Ax2d::Mirrored(const gp_Ax2d& A) const noexcept
 {
   gp_Ax2d AA = *this;
   AA.Mirror(A);

--- a/src/FoundationClasses/TKMath/gp/gp_Ax2d.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Ax2d.hxx
@@ -125,19 +125,19 @@ public:
     return aTemp;
   }
 
-  Standard_EXPORT void Mirror(const gp_Pnt2d& P);
+  Standard_EXPORT void Mirror(const gp_Pnt2d& P) noexcept;
 
   //! Performs the symmetrical transformation of an axis
   //! placement with respect to the point P which is the
   //! center of the symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Ax2d Mirrored(const gp_Pnt2d& P) const;
+  Standard_NODISCARD Standard_EXPORT gp_Ax2d Mirrored(const gp_Pnt2d& P) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax2d& A);
+  Standard_EXPORT void Mirror(const gp_Ax2d& A) noexcept;
 
   //! Performs the symmetrical transformation of an axis
   //! placement with respect to an axis placement which
   //! is the axis of the symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Ax2d Mirrored(const gp_Ax2d& A) const;
+  Standard_NODISCARD Standard_EXPORT gp_Ax2d Mirrored(const gp_Ax2d& A) const noexcept;
 
   void Rotate(const gp_Pnt2d& theP, const Standard_Real theAng)
   {

--- a/src/FoundationClasses/TKMath/gp/gp_Circ2d.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Circ2d.cxx
@@ -20,24 +20,24 @@
 #include <gp_Ax22d.hxx>
 #include <gp_Pnt2d.hxx>
 
-void gp_Circ2d::Mirror(const gp_Pnt2d& P)
+void gp_Circ2d::Mirror(const gp_Pnt2d& P) noexcept
 {
   pos.Mirror(P);
 }
 
-gp_Circ2d gp_Circ2d::Mirrored(const gp_Pnt2d& P) const
+gp_Circ2d gp_Circ2d::Mirrored(const gp_Pnt2d& P) const noexcept
 {
   gp_Circ2d C = *this;
   C.pos.Mirror(P);
   return C;
 }
 
-void gp_Circ2d::Mirror(const gp_Ax2d& A)
+void gp_Circ2d::Mirror(const gp_Ax2d& A) noexcept
 {
   pos.Mirror(A);
 }
 
-gp_Circ2d gp_Circ2d::Mirrored(const gp_Ax2d& A) const
+gp_Circ2d gp_Circ2d::Mirrored(const gp_Ax2d& A) const noexcept
 {
   gp_Circ2d C = *this;
   C.pos.Mirror(A);

--- a/src/FoundationClasses/TKMath/gp/gp_Circ2d.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Circ2d.hxx
@@ -127,7 +127,8 @@ public:
   //! Returns True if the distance between theP and any point on
   //! the circumference of the circle is lower of equal to
   //! <theLinearTolerance>.
-  Standard_Boolean Contains(const gp_Pnt2d& theP, const Standard_Real theLinearTolerance) const noexcept
+  Standard_Boolean Contains(const gp_Pnt2d&     theP,
+                            const Standard_Real theLinearTolerance) const noexcept
   {
     return Distance(theP) <= theLinearTolerance;
   }
@@ -180,7 +181,10 @@ public:
 
   //! Returns true if the local coordinate system is direct
   //! and false in the other case.
-  constexpr Standard_Boolean IsDirect() const noexcept { return (pos.XDirection().Crossed(pos.YDirection())) >= 0.0; }
+  constexpr Standard_Boolean IsDirect() const noexcept
+  {
+    return (pos.XDirection().Crossed(pos.YDirection())) >= 0.0;
+  }
 
   Standard_EXPORT void Mirror(const gp_Pnt2d& theP) noexcept;
 
@@ -194,11 +198,15 @@ public:
   //! to an axis placement which is the axis of the symmetry.
   Standard_NODISCARD Standard_EXPORT gp_Circ2d Mirrored(const gp_Ax2d& theA) const noexcept;
 
-  void Rotate(const gp_Pnt2d& theP, const Standard_Real theAng) noexcept { pos.Rotate(theP, theAng); }
+  void Rotate(const gp_Pnt2d& theP, const Standard_Real theAng) noexcept
+  {
+    pos.Rotate(theP, theAng);
+  }
 
   //! Rotates a circle. theP is the center of the rotation.
   //! Ang is the angular value of the rotation in radians.
-  Standard_NODISCARD gp_Circ2d Rotated(const gp_Pnt2d& theP, const Standard_Real theAng) const noexcept
+  Standard_NODISCARD gp_Circ2d Rotated(const gp_Pnt2d&     theP,
+                                       const Standard_Real theAng) const noexcept
   {
     gp_Circ2d aCirc = *this;
     aCirc.pos.Rotate(theP, theAng);
@@ -212,7 +220,8 @@ public:
   //! If theS is negative the radius stay positive but
   //! the "XAxis" and the "YAxis" are  reversed as for
   //! an ellipse.
-  Standard_NODISCARD gp_Circ2d Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const noexcept;
+  Standard_NODISCARD gp_Circ2d Scaled(const gp_Pnt2d&     theP,
+                                      const Standard_Real theS) const noexcept;
 
   void Transform(const gp_Trsf2d& theT) noexcept;
 
@@ -230,10 +239,14 @@ public:
     return aCirc;
   }
 
-  constexpr void Translate(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) noexcept { pos.Translate(theP1, theP2); }
+  constexpr void Translate(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) noexcept
+  {
+    pos.Translate(theP1, theP2);
+  }
 
   //! Translates a circle from the point theP1 to the point theP2.
-  Standard_NODISCARD gp_Circ2d Translated(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) const noexcept
+  Standard_NODISCARD gp_Circ2d Translated(const gp_Pnt2d& theP1,
+                                          const gp_Pnt2d& theP2) const noexcept
   {
     gp_Circ2d aCirc = *this;
     aCirc.pos.Translate(theP1, theP2);

--- a/src/FoundationClasses/TKMath/gp/gp_Circ2d.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Circ2d.hxx
@@ -52,7 +52,7 @@ public:
   DEFINE_STANDARD_ALLOC
 
   //! creates an indefinite circle.
-  gp_Circ2d()
+  gp_Circ2d() noexcept
       : radius(RealLast())
   {
   }
@@ -86,13 +86,13 @@ public:
   }
 
   //! Changes the location point (center) of the circle.
-  void SetLocation(const gp_Pnt2d& theP) { pos.SetLocation(theP); }
+  constexpr void SetLocation(const gp_Pnt2d& theP) noexcept { pos.SetLocation(theP); }
 
   //! Changes the X axis of the circle.
   void SetXAxis(const gp_Ax2d& theA) { pos.SetXAxis(theA); }
 
   //! Changes the X axis of the circle.
-  void SetAxis(const gp_Ax22d& theA) { pos.SetAxis(theA); }
+  constexpr void SetAxis(const gp_Ax22d& theA) noexcept { pos.SetAxis(theA); }
 
   //! Changes the Y axis of the circle.
   void SetYAxis(const gp_Ax2d& theA) { pos.SetYAxis(theA); }
@@ -111,61 +111,61 @@ public:
   }
 
   //! Computes the area of the circle.
-  Standard_Real Area() const { return M_PI * radius * radius; }
+  constexpr Standard_Real Area() const noexcept { return M_PI * radius * radius; }
 
   //! Returns the normalized coefficients from the implicit equation
   //! of the circle :
   //! theA * (X**2) + theB * (Y**2) + 2*theC*(X*Y) + 2*theD*X + 2*theE*Y + theF = 0.0
-  void Coefficients(Standard_Real& theA,
-                    Standard_Real& theB,
-                    Standard_Real& theC,
-                    Standard_Real& theD,
-                    Standard_Real& theE,
-                    Standard_Real& theF) const;
+  constexpr void Coefficients(Standard_Real& theA,
+                              Standard_Real& theB,
+                              Standard_Real& theC,
+                              Standard_Real& theD,
+                              Standard_Real& theE,
+                              Standard_Real& theF) const noexcept;
 
   //! Does <me> contain theP ?
   //! Returns True if the distance between theP and any point on
   //! the circumference of the circle is lower of equal to
   //! <theLinearTolerance>.
-  Standard_Boolean Contains(const gp_Pnt2d& theP, const Standard_Real theLinearTolerance) const
+  Standard_Boolean Contains(const gp_Pnt2d& theP, const Standard_Real theLinearTolerance) const noexcept
   {
     return Distance(theP) <= theLinearTolerance;
   }
 
   //! Computes the minimum of distance between the point theP and any
   //! point on the circumference of the circle.
-  Standard_Real Distance(const gp_Pnt2d& theP) const;
+  Standard_Real Distance(const gp_Pnt2d& theP) const noexcept;
 
   //! Computes the square distance between <me> and the point theP.
-  Standard_Real SquareDistance(const gp_Pnt2d& theP) const;
+  Standard_Real SquareDistance(const gp_Pnt2d& theP) const noexcept;
 
   //! computes the circumference of the circle.
-  Standard_Real Length() const { return 2. * M_PI * radius; }
+  constexpr Standard_Real Length() const noexcept { return 2. * M_PI * radius; }
 
   //! Returns the location point (center) of the circle.
-  const gp_Pnt2d& Location() const { return pos.Location(); }
+  constexpr const gp_Pnt2d& Location() const noexcept { return pos.Location(); }
 
   //! Returns the radius value of the circle.
-  Standard_Real Radius() const { return radius; }
+  constexpr Standard_Real Radius() const noexcept { return radius; }
 
   //! returns the position of the circle.
-  const gp_Ax22d& Axis() const { return pos; }
+  constexpr const gp_Ax22d& Axis() const noexcept { return pos; }
 
   //! returns the position of the circle. Idem Axis(me).
-  const gp_Ax22d& Position() const { return pos; }
+  constexpr const gp_Ax22d& Position() const noexcept { return pos; }
 
   //! returns the X axis of the circle.
-  gp_Ax2d XAxis() const { return gp_Ax2d(pos.XAxis()); }
+  gp_Ax2d XAxis() const noexcept { return gp_Ax2d(pos.XAxis()); }
 
   //! Returns the Y axis of the circle.
   //! Reverses the direction of the circle.
-  gp_Ax2d YAxis() const { return gp_Ax2d(pos.YAxis()); }
+  gp_Ax2d YAxis() const noexcept { return gp_Ax2d(pos.YAxis()); }
 
   //! Reverses the orientation of the local coordinate system
   //! of this circle (the "Y Direction" is reversed) and therefore
   //! changes the implicit orientation of this circle.
   //! Reverse assigns the result to this circle,
-  void Reverse()
+  void Reverse() noexcept
   {
     gp_Dir2d aTemp = pos.YDirection();
     aTemp.Reverse();
@@ -176,64 +176,64 @@ public:
   //! of this circle (the "Y Direction" is reversed) and therefore
   //! changes the implicit orientation of this circle.
   //! Reversed creates a new circle.
-  Standard_NODISCARD gp_Circ2d Reversed() const;
+  Standard_NODISCARD gp_Circ2d Reversed() const noexcept;
 
   //! Returns true if the local coordinate system is direct
   //! and false in the other case.
-  Standard_Boolean IsDirect() const { return (pos.XDirection().Crossed(pos.YDirection())) >= 0.0; }
+  constexpr Standard_Boolean IsDirect() const noexcept { return (pos.XDirection().Crossed(pos.YDirection())) >= 0.0; }
 
-  Standard_EXPORT void Mirror(const gp_Pnt2d& theP);
+  Standard_EXPORT void Mirror(const gp_Pnt2d& theP) noexcept;
 
   //! Performs the symmetrical transformation of a circle with respect
   //! to the point theP which is the center of the symmetry
-  Standard_NODISCARD Standard_EXPORT gp_Circ2d Mirrored(const gp_Pnt2d& theP) const;
+  Standard_NODISCARD Standard_EXPORT gp_Circ2d Mirrored(const gp_Pnt2d& theP) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax2d& theA);
+  Standard_EXPORT void Mirror(const gp_Ax2d& theA) noexcept;
 
   //! Performs the symmetrical transformation of a circle with respect
   //! to an axis placement which is the axis of the symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Circ2d Mirrored(const gp_Ax2d& theA) const;
+  Standard_NODISCARD Standard_EXPORT gp_Circ2d Mirrored(const gp_Ax2d& theA) const noexcept;
 
-  void Rotate(const gp_Pnt2d& theP, const Standard_Real theAng) { pos.Rotate(theP, theAng); }
+  void Rotate(const gp_Pnt2d& theP, const Standard_Real theAng) noexcept { pos.Rotate(theP, theAng); }
 
   //! Rotates a circle. theP is the center of the rotation.
   //! Ang is the angular value of the rotation in radians.
-  Standard_NODISCARD gp_Circ2d Rotated(const gp_Pnt2d& theP, const Standard_Real theAng) const
+  Standard_NODISCARD gp_Circ2d Rotated(const gp_Pnt2d& theP, const Standard_Real theAng) const noexcept
   {
     gp_Circ2d aCirc = *this;
     aCirc.pos.Rotate(theP, theAng);
     return aCirc;
   }
 
-  void Scale(const gp_Pnt2d& theP, const Standard_Real theS);
+  void Scale(const gp_Pnt2d& theP, const Standard_Real theS) noexcept;
 
   //! Scales a circle. theS is the scaling value.
   //! Warnings :
   //! If theS is negative the radius stay positive but
   //! the "XAxis" and the "YAxis" are  reversed as for
   //! an ellipse.
-  Standard_NODISCARD gp_Circ2d Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const;
+  Standard_NODISCARD gp_Circ2d Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const noexcept;
 
-  void Transform(const gp_Trsf2d& theT);
+  void Transform(const gp_Trsf2d& theT) noexcept;
 
   //! Transforms a circle with the transformation theT from class Trsf2d.
-  Standard_NODISCARD gp_Circ2d Transformed(const gp_Trsf2d& theT) const;
+  Standard_NODISCARD gp_Circ2d Transformed(const gp_Trsf2d& theT) const noexcept;
 
-  void Translate(const gp_Vec2d& theV) { pos.Translate(theV); }
+  constexpr void Translate(const gp_Vec2d& theV) noexcept { pos.Translate(theV); }
 
   //! Translates a circle in the direction of the vector theV.
   //! The magnitude of the translation is the vector's magnitude.
-  Standard_NODISCARD gp_Circ2d Translated(const gp_Vec2d& theV) const
+  Standard_NODISCARD gp_Circ2d Translated(const gp_Vec2d& theV) const noexcept
   {
     gp_Circ2d aCirc = *this;
     aCirc.pos.Translate(theV);
     return aCirc;
   }
 
-  void Translate(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) { pos.Translate(theP1, theP2); }
+  constexpr void Translate(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) noexcept { pos.Translate(theP1, theP2); }
 
   //! Translates a circle from the point theP1 to the point theP2.
-  Standard_NODISCARD gp_Circ2d Translated(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) const
+  Standard_NODISCARD gp_Circ2d Translated(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) const noexcept
   {
     gp_Circ2d aCirc = *this;
     aCirc.pos.Translate(theP1, theP2);
@@ -247,12 +247,12 @@ private:
 
 //=================================================================================================
 
-inline void gp_Circ2d::Coefficients(Standard_Real& theA,
-                                    Standard_Real& theB,
-                                    Standard_Real& theC,
-                                    Standard_Real& theD,
-                                    Standard_Real& theE,
-                                    Standard_Real& theF) const
+constexpr inline void gp_Circ2d::Coefficients(Standard_Real& theA,
+                                              Standard_Real& theB,
+                                              Standard_Real& theC,
+                                              Standard_Real& theD,
+                                              Standard_Real& theE,
+                                              Standard_Real& theF) const noexcept
 {
   Standard_Real aXc  = pos.Location().X();
   Standard_Real anYc = pos.Location().Y();
@@ -266,7 +266,7 @@ inline void gp_Circ2d::Coefficients(Standard_Real& theA,
 
 //=================================================================================================
 
-inline Standard_Real gp_Circ2d::Distance(const gp_Pnt2d& theP) const
+inline Standard_Real gp_Circ2d::Distance(const gp_Pnt2d& theP) const noexcept
 {
   gp_XY aCoord = theP.XY();
   aCoord.Subtract(pos.Location().XY());
@@ -280,7 +280,7 @@ inline Standard_Real gp_Circ2d::Distance(const gp_Pnt2d& theP) const
 
 //=================================================================================================
 
-inline gp_Circ2d gp_Circ2d::Reversed() const
+inline gp_Circ2d gp_Circ2d::Reversed() const noexcept
 {
   gp_Circ2d aCirc = *this;
   gp_Dir2d  aTemp = pos.YDirection();
@@ -291,7 +291,7 @@ inline gp_Circ2d gp_Circ2d::Reversed() const
 
 //=================================================================================================
 
-inline Standard_Real gp_Circ2d::SquareDistance(const gp_Pnt2d& theP) const
+inline Standard_Real gp_Circ2d::SquareDistance(const gp_Pnt2d& theP) const noexcept
 {
   gp_XY aCoord = theP.XY();
   aCoord.Subtract(pos.Location().XY());
@@ -301,7 +301,7 @@ inline Standard_Real gp_Circ2d::SquareDistance(const gp_Pnt2d& theP) const
 
 //=================================================================================================
 
-inline void gp_Circ2d::Scale(const gp_Pnt2d& theP, const Standard_Real theS)
+inline void gp_Circ2d::Scale(const gp_Pnt2d& theP, const Standard_Real theS) noexcept
 {
   radius *= theS;
   if (radius < 0)
@@ -313,7 +313,7 @@ inline void gp_Circ2d::Scale(const gp_Pnt2d& theP, const Standard_Real theS)
 
 //=================================================================================================
 
-inline gp_Circ2d gp_Circ2d::Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const
+inline gp_Circ2d gp_Circ2d::Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const noexcept
 {
   gp_Circ2d aCirc = *this;
   aCirc.radius *= theS;
@@ -327,7 +327,7 @@ inline gp_Circ2d gp_Circ2d::Scaled(const gp_Pnt2d& theP, const Standard_Real the
 
 //=================================================================================================
 
-inline void gp_Circ2d::Transform(const gp_Trsf2d& theT)
+inline void gp_Circ2d::Transform(const gp_Trsf2d& theT) noexcept
 {
   radius *= theT.ScaleFactor();
   if (radius < 0)
@@ -339,7 +339,7 @@ inline void gp_Circ2d::Transform(const gp_Trsf2d& theT)
 
 //=================================================================================================
 
-inline gp_Circ2d gp_Circ2d::Transformed(const gp_Trsf2d& theT) const
+inline gp_Circ2d gp_Circ2d::Transformed(const gp_Trsf2d& theT) const noexcept
 {
   gp_Circ2d aCirc = *this;
   aCirc.radius *= theT.ScaleFactor();

--- a/src/FoundationClasses/TKMath/gp/gp_Circ2d.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Circ2d.hxx
@@ -198,15 +198,11 @@ public:
   //! to an axis placement which is the axis of the symmetry.
   Standard_NODISCARD Standard_EXPORT gp_Circ2d Mirrored(const gp_Ax2d& theA) const noexcept;
 
-  void Rotate(const gp_Pnt2d& theP, const Standard_Real theAng)
-  {
-    pos.Rotate(theP, theAng);
-  }
+  void Rotate(const gp_Pnt2d& theP, const Standard_Real theAng) { pos.Rotate(theP, theAng); }
 
   //! Rotates a circle. theP is the center of the rotation.
   //! Ang is the angular value of the rotation in radians.
-  Standard_NODISCARD gp_Circ2d Rotated(const gp_Pnt2d&     theP,
-                                       const Standard_Real theAng) const
+  Standard_NODISCARD gp_Circ2d Rotated(const gp_Pnt2d& theP, const Standard_Real theAng) const
   {
     gp_Circ2d aCirc = *this;
     aCirc.pos.Rotate(theP, theAng);
@@ -220,8 +216,7 @@ public:
   //! If theS is negative the radius stay positive but
   //! the "XAxis" and the "YAxis" are  reversed as for
   //! an ellipse.
-  Standard_NODISCARD gp_Circ2d Scaled(const gp_Pnt2d&     theP,
-                                      const Standard_Real theS) const;
+  Standard_NODISCARD gp_Circ2d Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const;
 
   void Transform(const gp_Trsf2d& theT);
 

--- a/src/FoundationClasses/TKMath/gp/gp_Circ2d.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Circ2d.hxx
@@ -198,7 +198,7 @@ public:
   //! to an axis placement which is the axis of the symmetry.
   Standard_NODISCARD Standard_EXPORT gp_Circ2d Mirrored(const gp_Ax2d& theA) const noexcept;
 
-  void Rotate(const gp_Pnt2d& theP, const Standard_Real theAng) noexcept
+  void Rotate(const gp_Pnt2d& theP, const Standard_Real theAng)
   {
     pos.Rotate(theP, theAng);
   }
@@ -206,14 +206,14 @@ public:
   //! Rotates a circle. theP is the center of the rotation.
   //! Ang is the angular value of the rotation in radians.
   Standard_NODISCARD gp_Circ2d Rotated(const gp_Pnt2d&     theP,
-                                       const Standard_Real theAng) const noexcept
+                                       const Standard_Real theAng) const
   {
     gp_Circ2d aCirc = *this;
     aCirc.pos.Rotate(theP, theAng);
     return aCirc;
   }
 
-  void Scale(const gp_Pnt2d& theP, const Standard_Real theS) noexcept;
+  void Scale(const gp_Pnt2d& theP, const Standard_Real theS);
 
   //! Scales a circle. theS is the scaling value.
   //! Warnings :
@@ -221,12 +221,12 @@ public:
   //! the "XAxis" and the "YAxis" are  reversed as for
   //! an ellipse.
   Standard_NODISCARD gp_Circ2d Scaled(const gp_Pnt2d&     theP,
-                                      const Standard_Real theS) const noexcept;
+                                      const Standard_Real theS) const;
 
-  void Transform(const gp_Trsf2d& theT) noexcept;
+  void Transform(const gp_Trsf2d& theT);
 
   //! Transforms a circle with the transformation theT from class Trsf2d.
-  Standard_NODISCARD gp_Circ2d Transformed(const gp_Trsf2d& theT) const noexcept;
+  Standard_NODISCARD gp_Circ2d Transformed(const gp_Trsf2d& theT) const;
 
   constexpr void Translate(const gp_Vec2d& theV) noexcept { pos.Translate(theV); }
 
@@ -314,7 +314,7 @@ inline Standard_Real gp_Circ2d::SquareDistance(const gp_Pnt2d& theP) const noexc
 
 //=================================================================================================
 
-inline void gp_Circ2d::Scale(const gp_Pnt2d& theP, const Standard_Real theS) noexcept
+inline void gp_Circ2d::Scale(const gp_Pnt2d& theP, const Standard_Real theS)
 {
   radius *= theS;
   if (radius < 0)
@@ -326,7 +326,7 @@ inline void gp_Circ2d::Scale(const gp_Pnt2d& theP, const Standard_Real theS) noe
 
 //=================================================================================================
 
-inline gp_Circ2d gp_Circ2d::Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const noexcept
+inline gp_Circ2d gp_Circ2d::Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const
 {
   gp_Circ2d aCirc = *this;
   aCirc.radius *= theS;
@@ -340,7 +340,7 @@ inline gp_Circ2d gp_Circ2d::Scaled(const gp_Pnt2d& theP, const Standard_Real the
 
 //=================================================================================================
 
-inline void gp_Circ2d::Transform(const gp_Trsf2d& theT) noexcept
+inline void gp_Circ2d::Transform(const gp_Trsf2d& theT)
 {
   radius *= theT.ScaleFactor();
   if (radius < 0)
@@ -352,7 +352,7 @@ inline void gp_Circ2d::Transform(const gp_Trsf2d& theT) noexcept
 
 //=================================================================================================
 
-inline gp_Circ2d gp_Circ2d::Transformed(const gp_Trsf2d& theT) const noexcept
+inline gp_Circ2d gp_Circ2d::Transformed(const gp_Trsf2d& theT) const
 {
   gp_Circ2d aCirc = *this;
   aCirc.radius *= theT.ScaleFactor();

--- a/src/FoundationClasses/TKMath/gp/gp_Dir2d.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Dir2d.cxx
@@ -54,7 +54,7 @@ Standard_Real gp_Dir2d::Angle(const gp_Dir2d& Other) const
   }
 }
 
-void gp_Dir2d::Mirror(const gp_Ax2d& A2)
+void gp_Dir2d::Mirror(const gp_Ax2d& A2) noexcept
 {
   const gp_XY&  XY = A2.Direction().XY();
   Standard_Real A  = XY.X();
@@ -67,7 +67,7 @@ void gp_Dir2d::Mirror(const gp_Ax2d& A2)
   coord.SetCoord(XX, YY);
 }
 
-void gp_Dir2d::Transform(const gp_Trsf2d& T)
+void gp_Dir2d::Transform(const gp_Trsf2d& T) noexcept
 {
   if (T.Form() == gp_Identity || T.Form() == gp_Translation)
   {
@@ -95,7 +95,7 @@ void gp_Dir2d::Transform(const gp_Trsf2d& T)
   }
 }
 
-void gp_Dir2d::Mirror(const gp_Dir2d& V)
+void gp_Dir2d::Mirror(const gp_Dir2d& V) noexcept
 {
   const gp_XY&  XY = V.coord;
   Standard_Real A  = XY.X();
@@ -108,14 +108,14 @@ void gp_Dir2d::Mirror(const gp_Dir2d& V)
   coord.SetCoord(XX, YY);
 }
 
-gp_Dir2d gp_Dir2d::Mirrored(const gp_Dir2d& V) const
+gp_Dir2d gp_Dir2d::Mirrored(const gp_Dir2d& V) const noexcept
 {
   gp_Dir2d Vres = *this;
   Vres.Mirror(V);
   return Vres;
 }
 
-gp_Dir2d gp_Dir2d::Mirrored(const gp_Ax2d& A) const
+gp_Dir2d gp_Dir2d::Mirrored(const gp_Ax2d& A) const noexcept
 {
   gp_Dir2d V = *this;
   V.Mirror(A);

--- a/src/FoundationClasses/TKMath/gp/gp_Dir2d.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Dir2d.hxx
@@ -218,19 +218,19 @@ public:
 
   Standard_NODISCARD constexpr gp_Dir2d operator-() const noexcept { return Reversed(); }
 
-  Standard_EXPORT void Mirror(const gp_Dir2d& theV);
+  Standard_EXPORT void Mirror(const gp_Dir2d& theV) noexcept;
 
   //! Performs the symmetrical transformation of a direction
   //! with respect to the direction theV which is the center of
   //! the  symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Dir2d Mirrored(const gp_Dir2d& theV) const;
+  Standard_NODISCARD Standard_EXPORT gp_Dir2d Mirrored(const gp_Dir2d& theV) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax2d& theA);
+  Standard_EXPORT void Mirror(const gp_Ax2d& theA) noexcept;
 
   //! Performs the symmetrical transformation of a direction
   //! with respect to an axis placement which is the axis
   //! of the symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Dir2d Mirrored(const gp_Ax2d& theA) const;
+  Standard_NODISCARD Standard_EXPORT gp_Dir2d Mirrored(const gp_Ax2d& theA) const noexcept;
 
   void Rotate(const Standard_Real Ang);
 
@@ -243,7 +243,7 @@ public:
     return aV;
   }
 
-  Standard_EXPORT void Transform(const gp_Trsf2d& theT);
+  Standard_EXPORT void Transform(const gp_Trsf2d& theT) noexcept;
 
   //! Transforms a direction with the "Trsf" theT.
   //! Warnings :

--- a/src/FoundationClasses/TKMath/gp/gp_Elips2d.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Elips2d.cxx
@@ -66,24 +66,24 @@ void gp_Elips2d::Coefficients(Standard_Real& A,
   }
 }
 
-void gp_Elips2d::Mirror(const gp_Pnt2d& P)
+void gp_Elips2d::Mirror(const gp_Pnt2d& P) noexcept
 {
   pos.Mirror(P);
 }
 
-gp_Elips2d gp_Elips2d::Mirrored(const gp_Pnt2d& P) const
+gp_Elips2d gp_Elips2d::Mirrored(const gp_Pnt2d& P) const noexcept
 {
   gp_Elips2d E = *this;
   E.pos.Mirror(P);
   return E;
 }
 
-void gp_Elips2d::Mirror(const gp_Ax2d& A)
+void gp_Elips2d::Mirror(const gp_Ax2d& A) noexcept
 {
   pos.Mirror(A);
 }
 
-gp_Elips2d gp_Elips2d::Mirrored(const gp_Ax2d& A) const
+gp_Elips2d gp_Elips2d::Mirrored(const gp_Ax2d& A) const noexcept
 {
   gp_Elips2d E = *this;
   E.pos.Mirror(A);

--- a/src/FoundationClasses/TKMath/gp/gp_Elips2d.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Elips2d.hxx
@@ -245,29 +245,29 @@ public:
   //! to an axis placement which is the axis of the symmetry.
   Standard_NODISCARD Standard_EXPORT gp_Elips2d Mirrored(const gp_Ax2d& theA) const noexcept;
 
-  void Rotate(const gp_Pnt2d& theP, const Standard_Real theAng) noexcept
+  void Rotate(const gp_Pnt2d& theP, const Standard_Real theAng)
   {
     pos.Rotate(theP, theAng);
   }
 
   Standard_NODISCARD gp_Elips2d Rotated(const gp_Pnt2d&     theP,
-                                        const Standard_Real theAng) const noexcept
+                                        const Standard_Real theAng) const
   {
     gp_Elips2d anE = *this;
     anE.pos.Rotate(theP, theAng);
     return anE;
   }
 
-  void Scale(const gp_Pnt2d& theP, const Standard_Real theS) noexcept;
+  void Scale(const gp_Pnt2d& theP, const Standard_Real theS);
 
   //! Scales a ellipse. theS is the scaling value.
   Standard_NODISCARD gp_Elips2d Scaled(const gp_Pnt2d&     theP,
-                                       const Standard_Real theS) const noexcept;
+                                       const Standard_Real theS) const;
 
-  void Transform(const gp_Trsf2d& theT) noexcept;
+  void Transform(const gp_Trsf2d& theT);
 
   //! Transforms an ellipse with the transformation theT from class Trsf2d.
-  Standard_NODISCARD gp_Elips2d Transformed(const gp_Trsf2d& theT) const noexcept;
+  Standard_NODISCARD gp_Elips2d Transformed(const gp_Trsf2d& theT) const;
 
   constexpr void Translate(const gp_Vec2d& theV) noexcept { pos.Translate(theV); }
 
@@ -362,7 +362,7 @@ inline gp_Pnt2d gp_Elips2d::Focus2() const
 
 //=================================================================================================
 
-inline void gp_Elips2d::Scale(const gp_Pnt2d& theP, const Standard_Real theS) noexcept
+inline void gp_Elips2d::Scale(const gp_Pnt2d& theP, const Standard_Real theS)
 {
   majorRadius *= theS;
   if (majorRadius < 0)
@@ -379,7 +379,7 @@ inline void gp_Elips2d::Scale(const gp_Pnt2d& theP, const Standard_Real theS) no
 
 //=================================================================================================
 
-inline gp_Elips2d gp_Elips2d::Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const noexcept
+inline gp_Elips2d gp_Elips2d::Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const
 {
   gp_Elips2d anE = *this;
   anE.majorRadius *= theS;
@@ -423,7 +423,7 @@ inline gp_Elips2d gp_Elips2d::Reversed() const noexcept
 
 //=================================================================================================
 
-inline void gp_Elips2d::Transform(const gp_Trsf2d& theT) noexcept
+inline void gp_Elips2d::Transform(const gp_Trsf2d& theT)
 {
   Standard_Real aTSca = theT.ScaleFactor();
   if (aTSca < 0.0)
@@ -437,7 +437,7 @@ inline void gp_Elips2d::Transform(const gp_Trsf2d& theT) noexcept
 
 //=================================================================================================
 
-inline gp_Elips2d gp_Elips2d::Transformed(const gp_Trsf2d& theT) const noexcept
+inline gp_Elips2d gp_Elips2d::Transformed(const gp_Trsf2d& theT) const
 {
   gp_Elips2d anE = *this;
   anE.majorRadius *= theT.ScaleFactor();

--- a/src/FoundationClasses/TKMath/gp/gp_Elips2d.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Elips2d.hxx
@@ -228,7 +228,10 @@ public:
 
   //! Returns true if the local coordinate system is direct
   //! and false in the other case.
-  constexpr Standard_Boolean IsDirect() const noexcept { return (pos.XDirection().Crossed(pos.YDirection())) >= 0.0; }
+  constexpr Standard_Boolean IsDirect() const noexcept
+  {
+    return (pos.XDirection().Crossed(pos.YDirection())) >= 0.0;
+  }
 
   Standard_EXPORT void Mirror(const gp_Pnt2d& theP) noexcept;
 
@@ -242,9 +245,13 @@ public:
   //! to an axis placement which is the axis of the symmetry.
   Standard_NODISCARD Standard_EXPORT gp_Elips2d Mirrored(const gp_Ax2d& theA) const noexcept;
 
-  void Rotate(const gp_Pnt2d& theP, const Standard_Real theAng) noexcept { pos.Rotate(theP, theAng); }
+  void Rotate(const gp_Pnt2d& theP, const Standard_Real theAng) noexcept
+  {
+    pos.Rotate(theP, theAng);
+  }
 
-  Standard_NODISCARD gp_Elips2d Rotated(const gp_Pnt2d& theP, const Standard_Real theAng) const noexcept
+  Standard_NODISCARD gp_Elips2d Rotated(const gp_Pnt2d&     theP,
+                                        const Standard_Real theAng) const noexcept
   {
     gp_Elips2d anE = *this;
     anE.pos.Rotate(theP, theAng);
@@ -254,7 +261,8 @@ public:
   void Scale(const gp_Pnt2d& theP, const Standard_Real theS) noexcept;
 
   //! Scales a ellipse. theS is the scaling value.
-  Standard_NODISCARD gp_Elips2d Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const noexcept;
+  Standard_NODISCARD gp_Elips2d Scaled(const gp_Pnt2d&     theP,
+                                       const Standard_Real theS) const noexcept;
 
   void Transform(const gp_Trsf2d& theT) noexcept;
 
@@ -272,10 +280,14 @@ public:
     return anE;
   }
 
-  constexpr void Translate(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) noexcept { pos.Translate(theP1, theP2); }
+  constexpr void Translate(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) noexcept
+  {
+    pos.Translate(theP1, theP2);
+  }
 
   //! Translates a ellipse from the point theP1 to the point theP2.
-  Standard_NODISCARD gp_Elips2d Translated(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) const noexcept
+  Standard_NODISCARD gp_Elips2d Translated(const gp_Pnt2d& theP1,
+                                           const gp_Pnt2d& theP2) const noexcept
   {
     gp_Elips2d anE = *this;
     anE.pos.Translate(theP1, theP2);

--- a/src/FoundationClasses/TKMath/gp/gp_Elips2d.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Elips2d.hxx
@@ -47,7 +47,7 @@ public:
   DEFINE_STANDARD_ALLOC
 
   //! Creates an indefinite ellipse.
-  gp_Elips2d()
+  gp_Elips2d() noexcept
       : majorRadius(RealLast()),
         minorRadius(RealSmall())
   {
@@ -101,7 +101,7 @@ public:
 
   //! Modifies this ellipse, by redefining its local coordinate system so that
   //! -   its origin becomes theP.
-  void SetLocation(const gp_Pnt2d& theP) { pos.SetLocation(theP); }
+  constexpr void SetLocation(const gp_Pnt2d& theP) noexcept { pos.SetLocation(theP); }
 
   //! Changes the value of the major radius.
   //! Raises ConstructionError if theMajorRadius < MinorRadius.
@@ -125,7 +125,7 @@ public:
 
   //! Modifies this ellipse, by redefining its local coordinate system so that
   //! it becomes theA.
-  void SetAxis(const gp_Ax22d& theA) { pos.SetAxis(theA); }
+  constexpr void SetAxis(const gp_Ax22d& theA) noexcept { pos.SetAxis(theA); }
 
   //! Modifies this ellipse, by redefining its local coordinate system so that
   //! its origin and its "X Direction"  become those
@@ -142,7 +142,7 @@ public:
   void SetYAxis(const gp_Ax2d& theA) { pos.SetYAxis(theA); }
 
   //! Computes the area of the ellipse.
-  Standard_Real Area() const { return M_PI * majorRadius * minorRadius; }
+  constexpr Standard_Real Area() const noexcept { return M_PI * majorRadius * minorRadius; }
 
   //! Returns the coefficients of the implicit equation of the ellipse.
   //! theA * (X**2) + theB * (Y**2) + 2*theC*(X*Y) + 2*theD*X + 2*theE*Y + theF = 0.
@@ -194,88 +194,88 @@ public:
   gp_Pnt2d Focus2() const;
 
   //! Returns the center of the ellipse.
-  const gp_Pnt2d& Location() const { return pos.Location(); }
+  constexpr const gp_Pnt2d& Location() const noexcept { return pos.Location(); }
 
   //! Returns the major radius of the Ellipse.
-  Standard_Real MajorRadius() const { return majorRadius; }
+  constexpr Standard_Real MajorRadius() const noexcept { return majorRadius; }
 
   //! Returns the minor radius of the Ellipse.
-  Standard_Real MinorRadius() const { return minorRadius; }
+  constexpr Standard_Real MinorRadius() const noexcept { return minorRadius; }
 
   //! Returns p = (1 - e * e) * MajorRadius where e is the eccentricity
   //! of the ellipse.
   //! Returns 0 if MajorRadius = 0
-  Standard_Real Parameter() const;
+  constexpr Standard_Real Parameter() const noexcept;
 
   //! Returns the major axis of the ellipse.
-  const gp_Ax22d& Axis() const { return pos; }
+  constexpr const gp_Ax22d& Axis() const noexcept { return pos; }
 
   //! Returns the major axis of the ellipse.
-  gp_Ax2d XAxis() const { return pos.XAxis(); }
+  gp_Ax2d XAxis() const noexcept { return pos.XAxis(); }
 
   //! Returns the minor axis of the ellipse.
   //! Reverses the direction of the circle.
-  gp_Ax2d YAxis() const { return pos.YAxis(); }
+  gp_Ax2d YAxis() const noexcept { return pos.YAxis(); }
 
-  void Reverse()
+  void Reverse() noexcept
   {
     gp_Dir2d aTemp = pos.YDirection();
     aTemp.Reverse();
     pos.SetAxis(gp_Ax22d(pos.Location(), pos.XDirection(), aTemp));
   }
 
-  Standard_NODISCARD gp_Elips2d Reversed() const;
+  Standard_NODISCARD gp_Elips2d Reversed() const noexcept;
 
   //! Returns true if the local coordinate system is direct
   //! and false in the other case.
-  Standard_Boolean IsDirect() const { return (pos.XDirection().Crossed(pos.YDirection())) >= 0.0; }
+  constexpr Standard_Boolean IsDirect() const noexcept { return (pos.XDirection().Crossed(pos.YDirection())) >= 0.0; }
 
-  Standard_EXPORT void Mirror(const gp_Pnt2d& theP);
+  Standard_EXPORT void Mirror(const gp_Pnt2d& theP) noexcept;
 
   //! Performs the symmetrical transformation of a ellipse with respect
   //! to the point theP which is the center of the symmetry
-  Standard_NODISCARD Standard_EXPORT gp_Elips2d Mirrored(const gp_Pnt2d& theP) const;
+  Standard_NODISCARD Standard_EXPORT gp_Elips2d Mirrored(const gp_Pnt2d& theP) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax2d& theA);
+  Standard_EXPORT void Mirror(const gp_Ax2d& theA) noexcept;
 
   //! Performs the symmetrical transformation of a ellipse with respect
   //! to an axis placement which is the axis of the symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Elips2d Mirrored(const gp_Ax2d& theA) const;
+  Standard_NODISCARD Standard_EXPORT gp_Elips2d Mirrored(const gp_Ax2d& theA) const noexcept;
 
-  void Rotate(const gp_Pnt2d& theP, const Standard_Real theAng) { pos.Rotate(theP, theAng); }
+  void Rotate(const gp_Pnt2d& theP, const Standard_Real theAng) noexcept { pos.Rotate(theP, theAng); }
 
-  Standard_NODISCARD gp_Elips2d Rotated(const gp_Pnt2d& theP, const Standard_Real theAng) const
+  Standard_NODISCARD gp_Elips2d Rotated(const gp_Pnt2d& theP, const Standard_Real theAng) const noexcept
   {
     gp_Elips2d anE = *this;
     anE.pos.Rotate(theP, theAng);
     return anE;
   }
 
-  void Scale(const gp_Pnt2d& theP, const Standard_Real theS);
+  void Scale(const gp_Pnt2d& theP, const Standard_Real theS) noexcept;
 
   //! Scales a ellipse. theS is the scaling value.
-  Standard_NODISCARD gp_Elips2d Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const;
+  Standard_NODISCARD gp_Elips2d Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const noexcept;
 
-  void Transform(const gp_Trsf2d& theT);
+  void Transform(const gp_Trsf2d& theT) noexcept;
 
   //! Transforms an ellipse with the transformation theT from class Trsf2d.
-  Standard_NODISCARD gp_Elips2d Transformed(const gp_Trsf2d& theT) const;
+  Standard_NODISCARD gp_Elips2d Transformed(const gp_Trsf2d& theT) const noexcept;
 
-  void Translate(const gp_Vec2d& theV) { pos.Translate(theV); }
+  constexpr void Translate(const gp_Vec2d& theV) noexcept { pos.Translate(theV); }
 
   //! Translates a ellipse in the direction of the vector theV.
   //! The magnitude of the translation is the vector's magnitude.
-  Standard_NODISCARD gp_Elips2d Translated(const gp_Vec2d& theV) const
+  Standard_NODISCARD gp_Elips2d Translated(const gp_Vec2d& theV) const noexcept
   {
     gp_Elips2d anE = *this;
     anE.pos.Translate(theV);
     return anE;
   }
 
-  void Translate(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) { pos.Translate(theP1, theP2); }
+  constexpr void Translate(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) noexcept { pos.Translate(theP1, theP2); }
 
   //! Translates a ellipse from the point theP1 to the point theP2.
-  Standard_NODISCARD gp_Elips2d Translated(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) const
+  Standard_NODISCARD gp_Elips2d Translated(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) const noexcept
   {
     gp_Elips2d anE = *this;
     anE.pos.Translate(theP1, theP2);
@@ -350,7 +350,7 @@ inline gp_Pnt2d gp_Elips2d::Focus2() const
 
 //=================================================================================================
 
-inline void gp_Elips2d::Scale(const gp_Pnt2d& theP, const Standard_Real theS)
+inline void gp_Elips2d::Scale(const gp_Pnt2d& theP, const Standard_Real theS) noexcept
 {
   majorRadius *= theS;
   if (majorRadius < 0)
@@ -367,7 +367,7 @@ inline void gp_Elips2d::Scale(const gp_Pnt2d& theP, const Standard_Real theS)
 
 //=================================================================================================
 
-inline gp_Elips2d gp_Elips2d::Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const
+inline gp_Elips2d gp_Elips2d::Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const noexcept
 {
   gp_Elips2d anE = *this;
   anE.majorRadius *= theS;
@@ -386,7 +386,7 @@ inline gp_Elips2d gp_Elips2d::Scaled(const gp_Pnt2d& theP, const Standard_Real t
 
 //=================================================================================================
 
-inline Standard_Real gp_Elips2d::Parameter() const
+inline constexpr Standard_Real gp_Elips2d::Parameter() const noexcept
 {
   if (majorRadius == 0.0)
   {
@@ -400,7 +400,7 @@ inline Standard_Real gp_Elips2d::Parameter() const
 
 //=================================================================================================
 
-inline gp_Elips2d gp_Elips2d::Reversed() const
+inline gp_Elips2d gp_Elips2d::Reversed() const noexcept
 {
   gp_Elips2d anE   = *this;
   gp_Dir2d   aTemp = pos.YDirection();
@@ -411,7 +411,7 @@ inline gp_Elips2d gp_Elips2d::Reversed() const
 
 //=================================================================================================
 
-inline void gp_Elips2d::Transform(const gp_Trsf2d& theT)
+inline void gp_Elips2d::Transform(const gp_Trsf2d& theT) noexcept
 {
   Standard_Real aTSca = theT.ScaleFactor();
   if (aTSca < 0.0)
@@ -425,7 +425,7 @@ inline void gp_Elips2d::Transform(const gp_Trsf2d& theT)
 
 //=================================================================================================
 
-inline gp_Elips2d gp_Elips2d::Transformed(const gp_Trsf2d& theT) const
+inline gp_Elips2d gp_Elips2d::Transformed(const gp_Trsf2d& theT) const noexcept
 {
   gp_Elips2d anE = *this;
   anE.majorRadius *= theT.ScaleFactor();

--- a/src/FoundationClasses/TKMath/gp/gp_Elips2d.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Elips2d.hxx
@@ -245,13 +245,9 @@ public:
   //! to an axis placement which is the axis of the symmetry.
   Standard_NODISCARD Standard_EXPORT gp_Elips2d Mirrored(const gp_Ax2d& theA) const noexcept;
 
-  void Rotate(const gp_Pnt2d& theP, const Standard_Real theAng)
-  {
-    pos.Rotate(theP, theAng);
-  }
+  void Rotate(const gp_Pnt2d& theP, const Standard_Real theAng) { pos.Rotate(theP, theAng); }
 
-  Standard_NODISCARD gp_Elips2d Rotated(const gp_Pnt2d&     theP,
-                                        const Standard_Real theAng) const
+  Standard_NODISCARD gp_Elips2d Rotated(const gp_Pnt2d& theP, const Standard_Real theAng) const
   {
     gp_Elips2d anE = *this;
     anE.pos.Rotate(theP, theAng);
@@ -261,8 +257,7 @@ public:
   void Scale(const gp_Pnt2d& theP, const Standard_Real theS);
 
   //! Scales a ellipse. theS is the scaling value.
-  Standard_NODISCARD gp_Elips2d Scaled(const gp_Pnt2d&     theP,
-                                       const Standard_Real theS) const;
+  Standard_NODISCARD gp_Elips2d Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const;
 
   void Transform(const gp_Trsf2d& theT);
 

--- a/src/FoundationClasses/TKMath/gp/gp_Hypr2d.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Hypr2d.cxx
@@ -66,24 +66,24 @@ void gp_Hypr2d::Coefficients(Standard_Real& A,
   }
 }
 
-void gp_Hypr2d::Mirror(const gp_Pnt2d& P)
+void gp_Hypr2d::Mirror(const gp_Pnt2d& P) noexcept
 {
   pos.Mirror(P);
 }
 
-gp_Hypr2d gp_Hypr2d::Mirrored(const gp_Pnt2d& P) const
+gp_Hypr2d gp_Hypr2d::Mirrored(const gp_Pnt2d& P) const noexcept
 {
   gp_Hypr2d H = *this;
   H.pos.Mirror(P);
   return H;
 }
 
-void gp_Hypr2d::Mirror(const gp_Ax2d& A)
+void gp_Hypr2d::Mirror(const gp_Ax2d& A) noexcept
 {
   pos.Mirror(A);
 }
 
-gp_Hypr2d gp_Hypr2d::Mirrored(const gp_Ax2d& A) const
+gp_Hypr2d gp_Hypr2d::Mirrored(const gp_Ax2d& A) const noexcept
 {
   gp_Hypr2d H = *this;
   H.pos.Mirror(A);

--- a/src/FoundationClasses/TKMath/gp/gp_Hypr2d.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Hypr2d.hxx
@@ -68,7 +68,7 @@ public:
   DEFINE_STANDARD_ALLOC
 
   //! Creates of an indefinite hyperbola.
-  gp_Hypr2d()
+  gp_Hypr2d() noexcept
       : majorRadius(RealLast()),
         minorRadius(RealLast())
   {
@@ -124,7 +124,7 @@ public:
 
   //! Modifies this hyperbola, by redefining its local
   //! coordinate system so that its origin becomes theP.
-  void SetLocation(const gp_Pnt2d& theP) { pos.SetLocation(theP); }
+  constexpr void SetLocation(const gp_Pnt2d& theP) noexcept { pos.SetLocation(theP); }
 
   //! Modifies the major or minor radius of this hyperbola.
   //! Exceptions
@@ -152,7 +152,7 @@ public:
 
   //! Modifies this hyperbola, by redefining its local
   //! coordinate system so that it becomes theA.
-  void SetAxis(const gp_Ax22d& theA) { pos.SetAxis(theA); }
+  constexpr void SetAxis(const gp_Ax22d& theA) noexcept { pos.SetAxis(theA); }
 
   //! Changes the major axis of the hyperbola. The minor axis is
   //! recomputed and the location of the hyperbola too.
@@ -190,7 +190,7 @@ public:
 
   //! Computes the branch of hyperbola which is on the positive side of the
   //! "YAxis" of <me>.
-  gp_Hypr2d ConjugateBranch1() const
+  gp_Hypr2d ConjugateBranch1() const noexcept
   {
     gp_Dir2d         aV(pos.YDirection());
     Standard_Boolean isSign = (pos.XDirection().Crossed(pos.YDirection())) >= 0.0;
@@ -199,7 +199,7 @@ public:
 
   //! Computes the branch of hyperbola which is on the negative side of the
   //! "YAxis" of <me>.
-  gp_Hypr2d ConjugateBranch2() const
+  gp_Hypr2d ConjugateBranch2() const noexcept
   {
     gp_Dir2d         aV(pos.YDirection().Reversed());
     Standard_Boolean isSign = (pos.XDirection().Crossed(pos.YDirection())) >= 0.0;
@@ -233,14 +233,14 @@ public:
 
   //! Computes the focal distance. It is the distance between the
   //! "Location" of the hyperbola and "Focus1" or "Focus2".
-  Standard_Real Focal() const
+  Standard_Real Focal() const noexcept
   {
     return 2.0 * sqrt(majorRadius * majorRadius + minorRadius * minorRadius);
   }
 
   //! Returns the first focus of the hyperbola. This focus is on the
   //! positive side of the "XAxis" of the hyperbola.
-  gp_Pnt2d Focus1() const
+  gp_Pnt2d Focus1() const noexcept
   {
     Standard_Real aC = sqrt(majorRadius * majorRadius + minorRadius * minorRadius);
     return gp_Pnt2d(pos.Location().X() + aC * pos.XDirection().X(),
@@ -249,7 +249,7 @@ public:
 
   //! Returns the second focus of the hyperbola. This focus is on the
   //! negative side of the "XAxis" of the hyperbola.
-  gp_Pnt2d Focus2() const
+  gp_Pnt2d Focus2() const noexcept
   {
     Standard_Real aC = sqrt(majorRadius * majorRadius + minorRadius * minorRadius);
     return gp_Pnt2d(pos.Location().X() - aC * pos.XDirection().X(),
@@ -259,20 +259,20 @@ public:
   //! Returns  the location point of the hyperbola.
   //! It is the intersection point between the "XAxis" and
   //! the "YAxis".
-  const gp_Pnt2d& Location() const { return pos.Location(); }
+  constexpr const gp_Pnt2d& Location() const noexcept { return pos.Location(); }
 
   //! Returns the major radius of the hyperbola (it is the radius
   //! corresponding to the "XAxis" of the hyperbola).
-  Standard_Real MajorRadius() const { return majorRadius; }
+  constexpr Standard_Real MajorRadius() const noexcept { return majorRadius; }
 
   //! Returns the minor radius of the hyperbola (it is the radius
   //! corresponding to the "YAxis" of the hyperbola).
-  Standard_Real MinorRadius() const { return minorRadius; }
+  constexpr Standard_Real MinorRadius() const noexcept { return minorRadius; }
 
   //! Returns the branch of hyperbola obtained by doing the
   //! symmetrical transformation of <me> with respect to the
   //! "YAxis" of <me>.
-  gp_Hypr2d OtherBranch() const
+  gp_Hypr2d OtherBranch() const noexcept
   {
     Standard_Boolean isSign = (pos.XDirection().Crossed(pos.YDirection())) >= 0.0;
     return gp_Hypr2d(gp_Ax2d(pos.Location(), pos.XDirection().Reversed()),
@@ -292,23 +292,23 @@ public:
   }
 
   //! Returns the axisplacement of the hyperbola.
-  const gp_Ax22d& Axis() const { return pos; }
+  constexpr const gp_Ax22d& Axis() const noexcept { return pos; }
 
   //! Computes an axis whose
   //! -   the origin is the center of this hyperbola, and
   //! -   the unit vector is the "X Direction" or "Y Direction"
   //! respectively of the local coordinate system of this hyperbola
   //! Returns the major axis of the hyperbola.
-  gp_Ax2d XAxis() const { return pos.XAxis(); }
+  gp_Ax2d XAxis() const noexcept { return pos.XAxis(); }
 
   //! Computes an axis whose
   //! -   the origin is the center of this hyperbola, and
   //! -   the unit vector is the "X Direction" or "Y Direction"
   //! respectively of the local coordinate system of this hyperbola
   //! Returns the minor axis of the hyperbola.
-  gp_Ax2d YAxis() const { return pos.YAxis(); }
+  gp_Ax2d YAxis() const noexcept { return pos.YAxis(); }
 
-  void Reverse()
+  void Reverse() noexcept
   {
     gp_Dir2d aTemp = pos.YDirection();
     aTemp.Reverse();
@@ -321,23 +321,23 @@ public:
   //! Note:
   //! -   Reverse assigns the result to this hyperbola, while
   //! -   Reversed creates a new one.
-  Standard_NODISCARD gp_Hypr2d Reversed() const;
+  Standard_NODISCARD gp_Hypr2d Reversed() const noexcept;
 
   //! Returns true if the local coordinate system is direct
   //! and false in the other case.
-  Standard_Boolean IsDirect() const { return (pos.XDirection().Crossed(pos.YDirection())) >= 0.0; }
+  constexpr Standard_Boolean IsDirect() const noexcept { return (pos.XDirection().Crossed(pos.YDirection())) >= 0.0; }
 
-  Standard_EXPORT void Mirror(const gp_Pnt2d& theP);
+  Standard_EXPORT void Mirror(const gp_Pnt2d& theP) noexcept;
 
   //! Performs the symmetrical transformation of an hyperbola with
   //! respect  to the point theP which is the center of the symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Hypr2d Mirrored(const gp_Pnt2d& theP) const;
+  Standard_NODISCARD Standard_EXPORT gp_Hypr2d Mirrored(const gp_Pnt2d& theP) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax2d& theA);
+  Standard_EXPORT void Mirror(const gp_Ax2d& theA) noexcept;
 
   //! Performs the symmetrical transformation of an hyperbola with
   //! respect to an axis placement which is the axis of the symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Hypr2d Mirrored(const gp_Ax2d& theA) const;
+  Standard_NODISCARD Standard_EXPORT gp_Hypr2d Mirrored(const gp_Ax2d& theA) const noexcept;
 
   void Rotate(const gp_Pnt2d& theP, const Standard_Real theAng) { pos.Rotate(theP, theAng); }
 
@@ -350,35 +350,35 @@ public:
     return aH;
   }
 
-  void Scale(const gp_Pnt2d& theP, const Standard_Real theS);
+  void Scale(const gp_Pnt2d& theP, const Standard_Real theS) noexcept;
 
   //! Scales an hyperbola. <theS> is the scaling value.
   //! If <theS> is positive only the location point is
   //! modified. But if <theS> is negative the "XAxis" is
   //! reversed and the "YAxis" too.
-  Standard_NODISCARD gp_Hypr2d Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const;
+  Standard_NODISCARD gp_Hypr2d Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const noexcept;
 
-  void Transform(const gp_Trsf2d& theT);
+  void Transform(const gp_Trsf2d& theT) noexcept;
 
   //! Transforms an hyperbola with the transformation theT from
   //! class Trsf2d.
-  Standard_NODISCARD gp_Hypr2d Transformed(const gp_Trsf2d& theT) const;
+  Standard_NODISCARD gp_Hypr2d Transformed(const gp_Trsf2d& theT) const noexcept;
 
-  void Translate(const gp_Vec2d& theV) { pos.Translate(theV); }
+  constexpr void Translate(const gp_Vec2d& theV) noexcept { pos.Translate(theV); }
 
   //! Translates an hyperbola in the direction of the vector theV.
   //! The magnitude of the translation is the vector's magnitude.
-  Standard_NODISCARD gp_Hypr2d Translated(const gp_Vec2d& theV) const
+  Standard_NODISCARD gp_Hypr2d Translated(const gp_Vec2d& theV) const noexcept
   {
     gp_Hypr2d aH = *this;
     aH.pos.Translate(theV);
     return aH;
   }
 
-  void Translate(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) { pos.Translate(theP1, theP2); }
+  constexpr void Translate(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) noexcept { pos.Translate(theP1, theP2); }
 
   //! Translates an hyperbola from the point theP1 to the point theP2.
-  Standard_NODISCARD gp_Hypr2d Translated(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) const
+  Standard_NODISCARD gp_Hypr2d Translated(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) const noexcept
   {
     gp_Hypr2d aH = *this;
     aH.pos.Translate(theP1, theP2);
@@ -443,7 +443,7 @@ inline gp_Ax2d gp_Hypr2d::Directrix2() const
 
 //=================================================================================================
 
-inline gp_Hypr2d gp_Hypr2d::Reversed() const
+inline gp_Hypr2d gp_Hypr2d::Reversed() const noexcept
 {
   gp_Hypr2d aH    = *this;
   gp_Dir2d  aTemp = pos.YDirection();
@@ -454,7 +454,7 @@ inline gp_Hypr2d gp_Hypr2d::Reversed() const
 
 //=================================================================================================
 
-inline void gp_Hypr2d::Scale(const gp_Pnt2d& theP, const Standard_Real theS)
+inline void gp_Hypr2d::Scale(const gp_Pnt2d& theP, const Standard_Real theS) noexcept
 {
   majorRadius *= theS;
   if (majorRadius < 0)
@@ -471,7 +471,7 @@ inline void gp_Hypr2d::Scale(const gp_Pnt2d& theP, const Standard_Real theS)
 
 //=================================================================================================
 
-inline gp_Hypr2d gp_Hypr2d::Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const
+inline gp_Hypr2d gp_Hypr2d::Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const noexcept
 {
   gp_Hypr2d aH = *this;
   aH.majorRadius *= theS;
@@ -490,7 +490,7 @@ inline gp_Hypr2d gp_Hypr2d::Scaled(const gp_Pnt2d& theP, const Standard_Real the
 
 //=================================================================================================
 
-inline void gp_Hypr2d::Transform(const gp_Trsf2d& theT)
+inline void gp_Hypr2d::Transform(const gp_Trsf2d& theT) noexcept
 {
   majorRadius *= theT.ScaleFactor();
   if (majorRadius < 0)
@@ -507,7 +507,7 @@ inline void gp_Hypr2d::Transform(const gp_Trsf2d& theT)
 
 //=================================================================================================
 
-inline gp_Hypr2d gp_Hypr2d::Transformed(const gp_Trsf2d& theT) const
+inline gp_Hypr2d gp_Hypr2d::Transformed(const gp_Trsf2d& theT) const noexcept
 {
   gp_Hypr2d aH = *this;
   aH.majorRadius *= theT.ScaleFactor();

--- a/src/FoundationClasses/TKMath/gp/gp_Hypr2d.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Hypr2d.hxx
@@ -325,7 +325,10 @@ public:
 
   //! Returns true if the local coordinate system is direct
   //! and false in the other case.
-  constexpr Standard_Boolean IsDirect() const noexcept { return (pos.XDirection().Crossed(pos.YDirection())) >= 0.0; }
+  constexpr Standard_Boolean IsDirect() const noexcept
+  {
+    return (pos.XDirection().Crossed(pos.YDirection())) >= 0.0;
+  }
 
   Standard_EXPORT void Mirror(const gp_Pnt2d& theP) noexcept;
 
@@ -356,7 +359,8 @@ public:
   //! If <theS> is positive only the location point is
   //! modified. But if <theS> is negative the "XAxis" is
   //! reversed and the "YAxis" too.
-  Standard_NODISCARD gp_Hypr2d Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const noexcept;
+  Standard_NODISCARD gp_Hypr2d Scaled(const gp_Pnt2d&     theP,
+                                      const Standard_Real theS) const noexcept;
 
   void Transform(const gp_Trsf2d& theT) noexcept;
 
@@ -375,10 +379,14 @@ public:
     return aH;
   }
 
-  constexpr void Translate(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) noexcept { pos.Translate(theP1, theP2); }
+  constexpr void Translate(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) noexcept
+  {
+    pos.Translate(theP1, theP2);
+  }
 
   //! Translates an hyperbola from the point theP1 to the point theP2.
-  Standard_NODISCARD gp_Hypr2d Translated(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) const noexcept
+  Standard_NODISCARD gp_Hypr2d Translated(const gp_Pnt2d& theP1,
+                                          const gp_Pnt2d& theP2) const noexcept
   {
     gp_Hypr2d aH = *this;
     aH.pos.Translate(theP1, theP2);

--- a/src/FoundationClasses/TKMath/gp/gp_Hypr2d.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Hypr2d.hxx
@@ -353,20 +353,20 @@ public:
     return aH;
   }
 
-  void Scale(const gp_Pnt2d& theP, const Standard_Real theS) noexcept;
+  void Scale(const gp_Pnt2d& theP, const Standard_Real theS);
 
   //! Scales an hyperbola. <theS> is the scaling value.
   //! If <theS> is positive only the location point is
   //! modified. But if <theS> is negative the "XAxis" is
   //! reversed and the "YAxis" too.
   Standard_NODISCARD gp_Hypr2d Scaled(const gp_Pnt2d&     theP,
-                                      const Standard_Real theS) const noexcept;
+                                      const Standard_Real theS) const;
 
-  void Transform(const gp_Trsf2d& theT) noexcept;
+  void Transform(const gp_Trsf2d& theT);
 
   //! Transforms an hyperbola with the transformation theT from
   //! class Trsf2d.
-  Standard_NODISCARD gp_Hypr2d Transformed(const gp_Trsf2d& theT) const noexcept;
+  Standard_NODISCARD gp_Hypr2d Transformed(const gp_Trsf2d& theT) const;
 
   constexpr void Translate(const gp_Vec2d& theV) noexcept { pos.Translate(theV); }
 
@@ -462,7 +462,7 @@ inline gp_Hypr2d gp_Hypr2d::Reversed() const noexcept
 
 //=================================================================================================
 
-inline void gp_Hypr2d::Scale(const gp_Pnt2d& theP, const Standard_Real theS) noexcept
+inline void gp_Hypr2d::Scale(const gp_Pnt2d& theP, const Standard_Real theS)
 {
   majorRadius *= theS;
   if (majorRadius < 0)
@@ -479,7 +479,7 @@ inline void gp_Hypr2d::Scale(const gp_Pnt2d& theP, const Standard_Real theS) noe
 
 //=================================================================================================
 
-inline gp_Hypr2d gp_Hypr2d::Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const noexcept
+inline gp_Hypr2d gp_Hypr2d::Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const
 {
   gp_Hypr2d aH = *this;
   aH.majorRadius *= theS;
@@ -498,7 +498,7 @@ inline gp_Hypr2d gp_Hypr2d::Scaled(const gp_Pnt2d& theP, const Standard_Real the
 
 //=================================================================================================
 
-inline void gp_Hypr2d::Transform(const gp_Trsf2d& theT) noexcept
+inline void gp_Hypr2d::Transform(const gp_Trsf2d& theT)
 {
   majorRadius *= theT.ScaleFactor();
   if (majorRadius < 0)
@@ -515,7 +515,7 @@ inline void gp_Hypr2d::Transform(const gp_Trsf2d& theT) noexcept
 
 //=================================================================================================
 
-inline gp_Hypr2d gp_Hypr2d::Transformed(const gp_Trsf2d& theT) const noexcept
+inline gp_Hypr2d gp_Hypr2d::Transformed(const gp_Trsf2d& theT) const
 {
   gp_Hypr2d aH = *this;
   aH.majorRadius *= theT.ScaleFactor();

--- a/src/FoundationClasses/TKMath/gp/gp_Hypr2d.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Hypr2d.hxx
@@ -359,8 +359,7 @@ public:
   //! If <theS> is positive only the location point is
   //! modified. But if <theS> is negative the "XAxis" is
   //! reversed and the "YAxis" too.
-  Standard_NODISCARD gp_Hypr2d Scaled(const gp_Pnt2d&     theP,
-                                      const Standard_Real theS) const;
+  Standard_NODISCARD gp_Hypr2d Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const;
 
   void Transform(const gp_Trsf2d& theT);
 

--- a/src/FoundationClasses/TKMath/gp/gp_Lin2d.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Lin2d.cxx
@@ -52,14 +52,14 @@ gp_Lin2d::gp_Lin2d(const Standard_Real A, const Standard_Real B, const Standard_
 
 //=================================================================================================
 
-void gp_Lin2d::Mirror(const gp_Pnt2d& P)
+void gp_Lin2d::Mirror(const gp_Pnt2d& P) noexcept
 {
   pos.Mirror(P);
 }
 
 //=================================================================================================
 
-gp_Lin2d gp_Lin2d::Mirrored(const gp_Pnt2d& P) const
+gp_Lin2d gp_Lin2d::Mirrored(const gp_Pnt2d& P) const noexcept
 {
   gp_Lin2d L = *this;
   L.pos.Mirror(P);
@@ -68,14 +68,14 @@ gp_Lin2d gp_Lin2d::Mirrored(const gp_Pnt2d& P) const
 
 //=================================================================================================
 
-void gp_Lin2d::Mirror(const gp_Ax2d& A)
+void gp_Lin2d::Mirror(const gp_Ax2d& A) noexcept
 {
   pos.Mirror(A);
 }
 
 //=================================================================================================
 
-gp_Lin2d gp_Lin2d::Mirrored(const gp_Ax2d& A) const
+gp_Lin2d gp_Lin2d::Mirrored(const gp_Ax2d& A) const noexcept
 {
   gp_Lin2d L = *this;
   L.pos.Mirror(A);

--- a/src/FoundationClasses/TKMath/gp/gp_Lin2d.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Lin2d.hxx
@@ -90,7 +90,9 @@ public:
 
   //! Returns the normalized coefficients of the line :
   //! theA * X + theB * Y + theC = 0.
-  constexpr void Coefficients(Standard_Real& theA, Standard_Real& theB, Standard_Real& theC) const noexcept
+  constexpr void Coefficients(Standard_Real& theA,
+                              Standard_Real& theB,
+                              Standard_Real& theC) const noexcept
   {
     theA = pos.Direction().Y();
     theB = -pos.Direction().X();
@@ -116,7 +118,8 @@ public:
   //! Returns true if this line contains the point theP, that is, if the
   //! distance between point theP and this line is less than or
   //! equal to theLinearTolerance.
-  Standard_Boolean Contains(const gp_Pnt2d& theP, const Standard_Real theLinearTolerance) const noexcept
+  Standard_Boolean Contains(const gp_Pnt2d&     theP,
+                            const Standard_Real theLinearTolerance) const noexcept
   {
     return Distance(theP) <= theLinearTolerance;
   }
@@ -198,10 +201,14 @@ public:
     return aL;
   }
 
-  constexpr void Translate(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) noexcept { pos.Translate(theP1, theP2); }
+  constexpr void Translate(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) noexcept
+  {
+    pos.Translate(theP1, theP2);
+  }
 
   //! Translates a line from the point theP1 to the point theP2.
-  Standard_NODISCARD gp_Lin2d Translated(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) const noexcept
+  Standard_NODISCARD gp_Lin2d Translated(const gp_Pnt2d& theP1,
+                                         const gp_Pnt2d& theP2) const noexcept
   {
     gp_Lin2d aL = *this;
     aL.pos.Translate(gp_Vec2d(theP1, theP2));

--- a/src/FoundationClasses/TKMath/gp/gp_Lin2d.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Lin2d.hxx
@@ -42,17 +42,17 @@ public:
 
   //! Creates a Line corresponding to X axis of the
   //! reference coordinate system.
-  gp_Lin2d() {}
+  constexpr gp_Lin2d() noexcept {}
 
   //! Creates a line located with theA.
-  gp_Lin2d(const gp_Ax2d& theA)
+  constexpr gp_Lin2d(const gp_Ax2d& theA) noexcept
       : pos(theA)
   {
   }
 
   //! <theP> is the location point (origin) of the line and
   //! <theV> is the direction of the line.
-  gp_Lin2d(const gp_Pnt2d& theP, const gp_Dir2d& theV)
+  constexpr gp_Lin2d(const gp_Pnt2d& theP, const gp_Dir2d& theV) noexcept
       : pos(theP, theV)
   {
   }
@@ -64,13 +64,13 @@ public:
                            const Standard_Real theB,
                            const Standard_Real theC);
 
-  void Reverse() { pos.Reverse(); }
+  constexpr void Reverse() noexcept { pos.Reverse(); }
 
   //! Reverses the positioning axis of this line.
   //! Note:
   //! -   Reverse assigns the result to this line, while
   //! -   Reversed creates a new one.
-  Standard_NODISCARD gp_Lin2d Reversed() const
+  Standard_NODISCARD constexpr gp_Lin2d Reversed() const noexcept
   {
     gp_Lin2d aL = *this;
     aL.pos.Reverse();
@@ -78,19 +78,19 @@ public:
   }
 
   //! Changes the direction of the line.
-  void SetDirection(const gp_Dir2d& theV) { pos.SetDirection(theV); }
+  constexpr void SetDirection(const gp_Dir2d& theV) noexcept { pos.SetDirection(theV); }
 
   //! Changes the origin of the line.
-  void SetLocation(const gp_Pnt2d& theP) { pos.SetLocation(theP); }
+  constexpr void SetLocation(const gp_Pnt2d& theP) noexcept { pos.SetLocation(theP); }
 
   //! Complete redefinition of the line.
   //! The "Location" point of <theA> is the origin of the line.
   //! The "Direction" of <theA> is  the direction of the line.
-  void SetPosition(const gp_Ax2d& theA) { pos = theA; }
+  constexpr void SetPosition(const gp_Ax2d& theA) noexcept { pos = theA; }
 
   //! Returns the normalized coefficients of the line :
   //! theA * X + theB * Y + theC = 0.
-  void Coefficients(Standard_Real& theA, Standard_Real& theB, Standard_Real& theC) const
+  constexpr void Coefficients(Standard_Real& theA, Standard_Real& theB, Standard_Real& theC) const noexcept
   {
     theA = pos.Direction().Y();
     theB = -pos.Direction().X();
@@ -98,14 +98,14 @@ public:
   }
 
   //! Returns the direction of the line.
-  const gp_Dir2d& Direction() const { return pos.Direction(); }
+  constexpr const gp_Dir2d& Direction() const noexcept { return pos.Direction(); }
 
   //! Returns the location point (origin) of the line.
-  const gp_Pnt2d& Location() const { return pos.Location(); }
+  constexpr const gp_Pnt2d& Location() const noexcept { return pos.Location(); }
 
   //! Returns the axis placement one axis with the same
   //! location and direction as <me>.
-  const gp_Ax2d& Position() const { return pos; }
+  constexpr const gp_Ax2d& Position() const noexcept { return pos; }
 
   //! Computes the angle between two lines in radians.
   Standard_Real Angle(const gp_Lin2d& theOther) const
@@ -116,44 +116,44 @@ public:
   //! Returns true if this line contains the point theP, that is, if the
   //! distance between point theP and this line is less than or
   //! equal to theLinearTolerance.
-  Standard_Boolean Contains(const gp_Pnt2d& theP, const Standard_Real theLinearTolerance) const
+  Standard_Boolean Contains(const gp_Pnt2d& theP, const Standard_Real theLinearTolerance) const noexcept
   {
     return Distance(theP) <= theLinearTolerance;
   }
 
   //! Computes the distance between <me> and the point <theP>.
-  Standard_Real Distance(const gp_Pnt2d& theP) const;
+  Standard_Real Distance(const gp_Pnt2d& theP) const noexcept;
 
   //! Computes the distance between two lines.
-  Standard_Real Distance(const gp_Lin2d& theOther) const;
+  Standard_Real Distance(const gp_Lin2d& theOther) const noexcept;
 
   //! Computes the square distance between <me> and the point
   //! <theP>.
-  Standard_Real SquareDistance(const gp_Pnt2d& theP) const;
+  constexpr Standard_Real SquareDistance(const gp_Pnt2d& theP) const noexcept;
 
   //! Computes the square distance between two lines.
-  Standard_Real SquareDistance(const gp_Lin2d& theOther) const;
+  Standard_Real SquareDistance(const gp_Lin2d& theOther) const noexcept;
 
   //! Computes the line normal to the direction of <me>,
   //! passing through the point <theP>.
-  gp_Lin2d Normal(const gp_Pnt2d& theP) const
+  gp_Lin2d Normal(const gp_Pnt2d& theP) const noexcept
   {
     return gp_Lin2d(gp_Ax2d(theP, gp_Dir2d(-(pos.Direction().Y()), pos.Direction().X())));
   }
 
-  Standard_EXPORT void Mirror(const gp_Pnt2d& theP);
+  Standard_EXPORT void Mirror(const gp_Pnt2d& theP) noexcept;
 
   //! Performs the symmetrical transformation of a line
   //! with respect to the point <theP> which is the center
   //! of the symmetry
-  Standard_NODISCARD Standard_EXPORT gp_Lin2d Mirrored(const gp_Pnt2d& theP) const;
+  Standard_NODISCARD Standard_EXPORT gp_Lin2d Mirrored(const gp_Pnt2d& theP) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax2d& theA);
+  Standard_EXPORT void Mirror(const gp_Ax2d& theA) noexcept;
 
   //! Performs the symmetrical transformation of a line
   //! with respect to an axis placement which is the axis
   //! of the symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Lin2d Mirrored(const gp_Ax2d& theA) const;
+  Standard_NODISCARD Standard_EXPORT gp_Lin2d Mirrored(const gp_Ax2d& theA) const noexcept;
 
   void Rotate(const gp_Pnt2d& theP, const Standard_Real theAng) { pos.Rotate(theP, theAng); }
 
@@ -177,31 +177,31 @@ public:
     return aL;
   }
 
-  void Transform(const gp_Trsf2d& theT) { pos.Transform(theT); }
+  void Transform(const gp_Trsf2d& theT) noexcept { pos.Transform(theT); }
 
   //! Transforms a line with the transformation theT from class Trsf2d.
-  Standard_NODISCARD gp_Lin2d Transformed(const gp_Trsf2d& theT) const
+  Standard_NODISCARD gp_Lin2d Transformed(const gp_Trsf2d& theT) const noexcept
   {
     gp_Lin2d aL = *this;
     aL.pos.Transform(theT);
     return aL;
   }
 
-  void Translate(const gp_Vec2d& theV) { pos.Translate(theV); }
+  constexpr void Translate(const gp_Vec2d& theV) noexcept { pos.Translate(theV); }
 
   //! Translates a line in the direction of the vector theV.
   //! The magnitude of the translation is the vector's magnitude.
-  Standard_NODISCARD gp_Lin2d Translated(const gp_Vec2d& theV) const
+  Standard_NODISCARD gp_Lin2d Translated(const gp_Vec2d& theV) const noexcept
   {
     gp_Lin2d aL = *this;
     aL.pos.Translate(theV);
     return aL;
   }
 
-  void Translate(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) { pos.Translate(theP1, theP2); }
+  constexpr void Translate(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) noexcept { pos.Translate(theP1, theP2); }
 
   //! Translates a line from the point theP1 to the point theP2.
-  Standard_NODISCARD gp_Lin2d Translated(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) const
+  Standard_NODISCARD gp_Lin2d Translated(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) const noexcept
   {
     gp_Lin2d aL = *this;
     aL.pos.Translate(gp_Vec2d(theP1, theP2));
@@ -214,7 +214,7 @@ private:
 
 //=================================================================================================
 
-inline Standard_Real gp_Lin2d::Distance(const gp_Pnt2d& theP) const
+inline Standard_Real gp_Lin2d::Distance(const gp_Pnt2d& theP) const noexcept
 {
   gp_XY aCoord = theP.XY();
   aCoord.Subtract((pos.Location()).XY());
@@ -228,7 +228,7 @@ inline Standard_Real gp_Lin2d::Distance(const gp_Pnt2d& theP) const
 
 //=================================================================================================
 
-inline Standard_Real gp_Lin2d::Distance(const gp_Lin2d& theOther) const
+inline Standard_Real gp_Lin2d::Distance(const gp_Lin2d& theOther) const noexcept
 {
   Standard_Real aD = 0.0;
   if (pos.IsParallel(theOther.pos, gp::Resolution()))
@@ -240,7 +240,7 @@ inline Standard_Real gp_Lin2d::Distance(const gp_Lin2d& theOther) const
 
 //=================================================================================================
 
-inline Standard_Real gp_Lin2d::SquareDistance(const gp_Pnt2d& theP) const
+inline constexpr Standard_Real gp_Lin2d::SquareDistance(const gp_Pnt2d& theP) const noexcept
 {
   gp_XY aCoord = theP.XY();
   aCoord.Subtract((pos.Location()).XY());
@@ -250,7 +250,7 @@ inline Standard_Real gp_Lin2d::SquareDistance(const gp_Pnt2d& theP) const
 
 //=================================================================================================
 
-inline Standard_Real gp_Lin2d::SquareDistance(const gp_Lin2d& theOther) const
+inline Standard_Real gp_Lin2d::SquareDistance(const gp_Lin2d& theOther) const noexcept
 {
   Standard_Real aD = 0.0;
   if (pos.IsParallel(theOther.pos, gp::Resolution()))

--- a/src/FoundationClasses/TKMath/gp/gp_Parab2d.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Parab2d.cxx
@@ -67,24 +67,24 @@ void gp_Parab2d::Coefficients(Standard_Real& A,
   F                 = (T23 * T23) - (2.0 * P * T13);
 }
 
-void gp_Parab2d::Mirror(const gp_Pnt2d& P)
+void gp_Parab2d::Mirror(const gp_Pnt2d& P) noexcept
 {
   pos.Mirror(P);
 }
 
-gp_Parab2d gp_Parab2d::Mirrored(const gp_Pnt2d& P) const
+gp_Parab2d gp_Parab2d::Mirrored(const gp_Pnt2d& P) const noexcept
 {
   gp_Parab2d Prb = *this;
   Prb.pos.Mirror(P);
   return Prb;
 }
 
-void gp_Parab2d::Mirror(const gp_Ax2d& A)
+void gp_Parab2d::Mirror(const gp_Ax2d& A) noexcept
 {
   pos.Mirror(A);
 }
 
-gp_Parab2d gp_Parab2d::Mirrored(const gp_Ax2d& A) const
+gp_Parab2d gp_Parab2d::Mirrored(const gp_Ax2d& A) const noexcept
 {
   gp_Parab2d Prb = *this;
   Prb.pos.Mirror(A);

--- a/src/FoundationClasses/TKMath/gp/gp_Parab2d.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Parab2d.hxx
@@ -224,8 +224,7 @@ public:
   //! Scales a parabola. theS is the scaling value.
   //! If theS is negative the direction of the symmetry axis
   //! "XAxis" is reversed and the direction of the "YAxis" too.
-  Standard_NODISCARD gp_Parab2d Scaled(const gp_Pnt2d&     theP,
-                                       const Standard_Real theS) const;
+  Standard_NODISCARD gp_Parab2d Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const;
 
   void Transform(const gp_Trsf2d& theT);
 

--- a/src/FoundationClasses/TKMath/gp/gp_Parab2d.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Parab2d.hxx
@@ -50,7 +50,7 @@ public:
   DEFINE_STANDARD_ALLOC
 
   //! Creates an indefinite parabola.
-  gp_Parab2d()
+  gp_Parab2d() noexcept
       : focalLength(RealLast())
   {
   }
@@ -113,7 +113,7 @@ public:
 
   //! Changes the "Location" point of the parabola. It is the
   //! vertex of the parabola.
-  void SetLocation(const gp_Pnt2d& theP) { pos.SetLocation(theP); }
+  constexpr void SetLocation(const gp_Pnt2d& theP) noexcept { pos.SetLocation(theP); }
 
   //! Modifies this parabola, by redefining its local coordinate system so that
   //! its origin and "X Direction" become those of the axis
@@ -124,7 +124,7 @@ public:
 
   //! Changes the local coordinate system of the parabola.
   //! The "Location" point of A becomes the vertex of the parabola.
-  void SetAxis(const gp_Ax22d& theA) { pos.SetAxis(theA); }
+  constexpr void SetAxis(const gp_Ax22d& theA) noexcept { pos.SetAxis(theA); }
 
   //! Computes the coefficients of the implicit equation of the parabola
   //! (in WCS - World Coordinate System).
@@ -146,35 +146,35 @@ public:
   //! at a distance from the apex which is equal to the focal  length of this parabola.
   //! The directrix is returned as an axis (a gp_Ax2d object),
   //! the origin of which is situated on the "X Axis" of this parabola.
-  gp_Ax2d Directrix() const;
+  gp_Ax2d Directrix() const noexcept;
 
   //! Returns the distance between the vertex and the focus
   //! of the parabola.
-  Standard_Real Focal() const { return focalLength; }
+  constexpr Standard_Real Focal() const noexcept { return focalLength; }
 
   //! Returns the focus of the parabola.
-  gp_Pnt2d Focus() const
+  gp_Pnt2d Focus() const noexcept
   {
     return gp_Pnt2d(pos.Location().X() + focalLength * pos.XDirection().X(),
                     pos.Location().Y() + focalLength * pos.XDirection().Y());
   }
 
   //! Returns the vertex of the parabola.
-  gp_Pnt2d Location() const { return pos.Location(); }
+  constexpr const gp_Pnt2d& Location() const noexcept { return pos.Location(); }
 
   //! Returns the symmetry axis of the parabola.
   //! The "Location" point of this axis is the vertex of the parabola.
-  gp_Ax2d MirrorAxis() const { return pos.XAxis(); }
+  gp_Ax2d MirrorAxis() const noexcept { return pos.XAxis(); }
 
   //! Returns the local coordinate system of the parabola.
   //! The "Location" point of this axis is the vertex of the parabola.
-  gp_Ax22d Axis() const { return pos; }
+  constexpr const gp_Ax22d& Axis() const noexcept { return pos; }
 
   //! Returns the distance between the focus and the
   //! directrix of the parabola.
-  Standard_Real Parameter() const { return 2.0 * focalLength; }
+  constexpr Standard_Real Parameter() const noexcept { return 2.0 * focalLength; }
 
-  void Reverse()
+  void Reverse() noexcept
   {
     gp_Dir2d aTemp = pos.YDirection();
     aTemp.Reverse();
@@ -187,23 +187,23 @@ public:
   //! Note:
   //! -   Reverse assigns the result to this parabola, while
   //! -   Reversed creates a new one.
-  Standard_NODISCARD gp_Parab2d Reversed() const;
+  Standard_NODISCARD gp_Parab2d Reversed() const noexcept;
 
   //! Returns true if the local coordinate system is direct
   //! and false in the other case.
-  Standard_Boolean IsDirect() const { return (pos.XDirection().Crossed(pos.YDirection())) >= 0.0; }
+  constexpr Standard_Boolean IsDirect() const noexcept { return (pos.XDirection().Crossed(pos.YDirection())) >= 0.0; }
 
-  Standard_EXPORT void Mirror(const gp_Pnt2d& theP);
+  Standard_EXPORT void Mirror(const gp_Pnt2d& theP) noexcept;
 
   //! Performs the symmetrical transformation of a parabola with respect
   //! to the point theP which is the center of the symmetry
-  Standard_NODISCARD Standard_EXPORT gp_Parab2d Mirrored(const gp_Pnt2d& theP) const;
+  Standard_NODISCARD Standard_EXPORT gp_Parab2d Mirrored(const gp_Pnt2d& theP) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax2d& theA);
+  Standard_EXPORT void Mirror(const gp_Ax2d& theA) noexcept;
 
   //! Performs the symmetrical transformation of a parabola with respect
   //! to an axis placement which is the axis of the symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Parab2d Mirrored(const gp_Ax2d& theA) const;
+  Standard_NODISCARD Standard_EXPORT gp_Parab2d Mirrored(const gp_Ax2d& theA) const noexcept;
 
   void Rotate(const gp_Pnt2d& theP, const Standard_Real theAng) { pos.Rotate(theP, theAng); }
 
@@ -216,33 +216,33 @@ public:
     return aPrb;
   }
 
-  void Scale(const gp_Pnt2d& theP, const Standard_Real theS);
+  void Scale(const gp_Pnt2d& theP, const Standard_Real theS) noexcept;
 
   //! Scales a parabola. theS is the scaling value.
   //! If theS is negative the direction of the symmetry axis
   //! "XAxis" is reversed and the direction of the "YAxis" too.
-  Standard_NODISCARD gp_Parab2d Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const;
+  Standard_NODISCARD gp_Parab2d Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const noexcept;
 
-  void Transform(const gp_Trsf2d& theT);
+  void Transform(const gp_Trsf2d& theT) noexcept;
 
   //! Transforms an parabola with the transformation theT from class Trsf2d.
-  Standard_NODISCARD gp_Parab2d Transformed(const gp_Trsf2d& theT) const;
+  Standard_NODISCARD gp_Parab2d Transformed(const gp_Trsf2d& theT) const noexcept;
 
-  void Translate(const gp_Vec2d& theV) { pos.Translate(theV); }
+  constexpr void Translate(const gp_Vec2d& theV) noexcept { pos.Translate(theV); }
 
   //! Translates a parabola in the direction of the vectorthe theV.
   //! The magnitude of the translation is the vector's magnitude.
-  Standard_NODISCARD gp_Parab2d Translated(const gp_Vec2d& theV) const
+  Standard_NODISCARD gp_Parab2d Translated(const gp_Vec2d& theV) const noexcept
   {
     gp_Parab2d aPrb = *this;
     aPrb.pos.Translate(theV);
     return aPrb;
   }
 
-  void Translate(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) { pos.Translate(theP1, theP2); }
+  constexpr void Translate(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) noexcept { pos.Translate(theP1, theP2); }
 
   //! Translates a parabola from the point theP1 to the point theP2.
-  Standard_NODISCARD gp_Parab2d Translated(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) const
+  Standard_NODISCARD gp_Parab2d Translated(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) const noexcept
   {
     gp_Parab2d aPrb = *this;
     aPrb.pos.Translate(theP1, theP2);
@@ -256,7 +256,7 @@ private:
 
 //=================================================================================================
 
-inline gp_Ax2d gp_Parab2d::Directrix() const
+inline gp_Ax2d gp_Parab2d::Directrix() const noexcept
 {
   gp_Pnt2d aP(pos.Location().X() - focalLength * pos.XDirection().X(),
               pos.Location().Y() - focalLength * pos.XDirection().Y());
@@ -266,7 +266,7 @@ inline gp_Ax2d gp_Parab2d::Directrix() const
 
 //=================================================================================================
 
-inline gp_Parab2d gp_Parab2d::Reversed() const
+inline gp_Parab2d gp_Parab2d::Reversed() const noexcept
 {
   gp_Parab2d aP    = *this;
   gp_Dir2d   aTemp = pos.YDirection();
@@ -277,7 +277,7 @@ inline gp_Parab2d gp_Parab2d::Reversed() const
 
 //=================================================================================================
 
-inline void gp_Parab2d::Scale(const gp_Pnt2d& theP, const Standard_Real theS)
+inline void gp_Parab2d::Scale(const gp_Pnt2d& theP, const Standard_Real theS) noexcept
 {
   focalLength *= theS;
   if (focalLength < 0)
@@ -289,7 +289,7 @@ inline void gp_Parab2d::Scale(const gp_Pnt2d& theP, const Standard_Real theS)
 
 //=================================================================================================
 
-inline gp_Parab2d gp_Parab2d::Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const
+inline gp_Parab2d gp_Parab2d::Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const noexcept
 {
   gp_Parab2d aPrb = *this;
   aPrb.focalLength *= theS;
@@ -303,7 +303,7 @@ inline gp_Parab2d gp_Parab2d::Scaled(const gp_Pnt2d& theP, const Standard_Real t
 
 //=================================================================================================
 
-inline void gp_Parab2d::Transform(const gp_Trsf2d& theT)
+inline void gp_Parab2d::Transform(const gp_Trsf2d& theT) noexcept
 {
   focalLength *= theT.ScaleFactor();
   if (focalLength < 0)
@@ -315,7 +315,7 @@ inline void gp_Parab2d::Transform(const gp_Trsf2d& theT)
 
 //=================================================================================================
 
-inline gp_Parab2d gp_Parab2d::Transformed(const gp_Trsf2d& theT) const
+inline gp_Parab2d gp_Parab2d::Transformed(const gp_Trsf2d& theT) const noexcept
 {
   gp_Parab2d aPrb = *this;
   aPrb.focalLength *= theT.ScaleFactor();

--- a/src/FoundationClasses/TKMath/gp/gp_Parab2d.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Parab2d.hxx
@@ -219,18 +219,18 @@ public:
     return aPrb;
   }
 
-  void Scale(const gp_Pnt2d& theP, const Standard_Real theS) noexcept;
+  void Scale(const gp_Pnt2d& theP, const Standard_Real theS);
 
   //! Scales a parabola. theS is the scaling value.
   //! If theS is negative the direction of the symmetry axis
   //! "XAxis" is reversed and the direction of the "YAxis" too.
   Standard_NODISCARD gp_Parab2d Scaled(const gp_Pnt2d&     theP,
-                                       const Standard_Real theS) const noexcept;
+                                       const Standard_Real theS) const;
 
-  void Transform(const gp_Trsf2d& theT) noexcept;
+  void Transform(const gp_Trsf2d& theT);
 
   //! Transforms an parabola with the transformation theT from class Trsf2d.
-  Standard_NODISCARD gp_Parab2d Transformed(const gp_Trsf2d& theT) const noexcept;
+  Standard_NODISCARD gp_Parab2d Transformed(const gp_Trsf2d& theT) const;
 
   constexpr void Translate(const gp_Vec2d& theV) noexcept { pos.Translate(theV); }
 
@@ -285,7 +285,7 @@ inline gp_Parab2d gp_Parab2d::Reversed() const noexcept
 
 //=================================================================================================
 
-inline void gp_Parab2d::Scale(const gp_Pnt2d& theP, const Standard_Real theS) noexcept
+inline void gp_Parab2d::Scale(const gp_Pnt2d& theP, const Standard_Real theS)
 {
   focalLength *= theS;
   if (focalLength < 0)
@@ -297,7 +297,7 @@ inline void gp_Parab2d::Scale(const gp_Pnt2d& theP, const Standard_Real theS) no
 
 //=================================================================================================
 
-inline gp_Parab2d gp_Parab2d::Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const noexcept
+inline gp_Parab2d gp_Parab2d::Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const
 {
   gp_Parab2d aPrb = *this;
   aPrb.focalLength *= theS;
@@ -311,7 +311,7 @@ inline gp_Parab2d gp_Parab2d::Scaled(const gp_Pnt2d& theP, const Standard_Real t
 
 //=================================================================================================
 
-inline void gp_Parab2d::Transform(const gp_Trsf2d& theT) noexcept
+inline void gp_Parab2d::Transform(const gp_Trsf2d& theT)
 {
   focalLength *= theT.ScaleFactor();
   if (focalLength < 0)
@@ -323,7 +323,7 @@ inline void gp_Parab2d::Transform(const gp_Trsf2d& theT) noexcept
 
 //=================================================================================================
 
-inline gp_Parab2d gp_Parab2d::Transformed(const gp_Trsf2d& theT) const noexcept
+inline gp_Parab2d gp_Parab2d::Transformed(const gp_Trsf2d& theT) const
 {
   gp_Parab2d aPrb = *this;
   aPrb.focalLength *= theT.ScaleFactor();

--- a/src/FoundationClasses/TKMath/gp/gp_Parab2d.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Parab2d.hxx
@@ -191,7 +191,10 @@ public:
 
   //! Returns true if the local coordinate system is direct
   //! and false in the other case.
-  constexpr Standard_Boolean IsDirect() const noexcept { return (pos.XDirection().Crossed(pos.YDirection())) >= 0.0; }
+  constexpr Standard_Boolean IsDirect() const noexcept
+  {
+    return (pos.XDirection().Crossed(pos.YDirection())) >= 0.0;
+  }
 
   Standard_EXPORT void Mirror(const gp_Pnt2d& theP) noexcept;
 
@@ -221,7 +224,8 @@ public:
   //! Scales a parabola. theS is the scaling value.
   //! If theS is negative the direction of the symmetry axis
   //! "XAxis" is reversed and the direction of the "YAxis" too.
-  Standard_NODISCARD gp_Parab2d Scaled(const gp_Pnt2d& theP, const Standard_Real theS) const noexcept;
+  Standard_NODISCARD gp_Parab2d Scaled(const gp_Pnt2d&     theP,
+                                       const Standard_Real theS) const noexcept;
 
   void Transform(const gp_Trsf2d& theT) noexcept;
 
@@ -239,10 +243,14 @@ public:
     return aPrb;
   }
 
-  constexpr void Translate(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) noexcept { pos.Translate(theP1, theP2); }
+  constexpr void Translate(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) noexcept
+  {
+    pos.Translate(theP1, theP2);
+  }
 
   //! Translates a parabola from the point theP1 to the point theP2.
-  Standard_NODISCARD gp_Parab2d Translated(const gp_Pnt2d& theP1, const gp_Pnt2d& theP2) const noexcept
+  Standard_NODISCARD gp_Parab2d Translated(const gp_Pnt2d& theP1,
+                                           const gp_Pnt2d& theP2) const noexcept
   {
     gp_Parab2d aPrb = *this;
     aPrb.pos.Translate(theP1, theP2);

--- a/src/FoundationClasses/TKMath/gp/gp_Pnt2d.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Pnt2d.cxx
@@ -24,7 +24,7 @@
 #include <Standard_Dump.hxx>
 #include <Standard_OutOfRange.hxx>
 
-void gp_Pnt2d::Transform(const gp_Trsf2d& T)
+void gp_Pnt2d::Transform(const gp_Trsf2d& T) noexcept
 {
   if (T.Form() == gp_Identity)
   {
@@ -49,7 +49,7 @@ void gp_Pnt2d::Transform(const gp_Trsf2d& T)
   }
 }
 
-void gp_Pnt2d::Mirror(const gp_Pnt2d& P)
+void gp_Pnt2d::Mirror(const gp_Pnt2d& P) noexcept
 {
   coord.Reverse();
   gp_XY XY = P.coord;
@@ -57,21 +57,21 @@ void gp_Pnt2d::Mirror(const gp_Pnt2d& P)
   coord.Add(XY);
 }
 
-gp_Pnt2d gp_Pnt2d::Mirrored(const gp_Pnt2d& P) const
+gp_Pnt2d gp_Pnt2d::Mirrored(const gp_Pnt2d& P) const noexcept
 {
   gp_Pnt2d Pres = *this;
   Pres.Mirror(P);
   return Pres;
 }
 
-void gp_Pnt2d::Mirror(const gp_Ax2d& A)
+void gp_Pnt2d::Mirror(const gp_Ax2d& A) noexcept
 {
   gp_Trsf2d T;
   T.SetMirror(A);
   T.Transforms(coord);
 }
 
-gp_Pnt2d gp_Pnt2d::Mirrored(const gp_Ax2d& A) const
+gp_Pnt2d gp_Pnt2d::Mirrored(const gp_Ax2d& A) const noexcept
 {
   gp_Pnt2d P = *this;
   P.Mirror(A);

--- a/src/FoundationClasses/TKMath/gp/gp_Pnt2d.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Pnt2d.hxx
@@ -120,15 +120,15 @@ public:
   //! Performs the symmetrical transformation of a point
   //! with respect to the point theP which is the center of
   //! the symmetry.
-  Standard_EXPORT void Mirror(const gp_Pnt2d& theP);
+  Standard_EXPORT void Mirror(const gp_Pnt2d& theP) noexcept;
 
   //! Performs the symmetrical transformation of a point
   //! with respect to an axis placement which is the axis
-  Standard_NODISCARD Standard_EXPORT gp_Pnt2d Mirrored(const gp_Pnt2d& theP) const;
+  Standard_NODISCARD Standard_EXPORT gp_Pnt2d Mirrored(const gp_Pnt2d& theP) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax2d& theA);
+  Standard_EXPORT void Mirror(const gp_Ax2d& theA) noexcept;
 
-  Standard_NODISCARD Standard_EXPORT gp_Pnt2d Mirrored(const gp_Ax2d& theA) const;
+  Standard_NODISCARD Standard_EXPORT gp_Pnt2d Mirrored(const gp_Ax2d& theA) const noexcept;
 
   //! Rotates a point. theA1 is the axis of the rotation.
   //! Ang is the angular value of the rotation in radians.
@@ -153,7 +153,7 @@ public:
   }
 
   //! Transforms a point with the transformation theT.
-  Standard_EXPORT void Transform(const gp_Trsf2d& theT);
+  Standard_EXPORT void Transform(const gp_Trsf2d& theT) noexcept;
 
   Standard_NODISCARD gp_Pnt2d Transformed(const gp_Trsf2d& theT) const
   {

--- a/src/FoundationClasses/TKMath/gp/gp_Trsf2d.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Trsf2d.cxx
@@ -28,7 +28,7 @@
 #include <gp_XY.hxx>
 #include <Standard_ConstructionError.hxx>
 
-void gp_Trsf2d::SetMirror(const gp_Ax2d& A)
+void gp_Trsf2d::SetMirror(const gp_Ax2d& A) noexcept
 {
   shape              = gp_Ax1Mirror;
   scale              = -1.0;

--- a/src/FoundationClasses/TKMath/gp/gp_Trsf2d.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Trsf2d.hxx
@@ -55,11 +55,11 @@ public:
 
   //! Changes the transformation into a symmetrical transformation.
   //! theP is the center of the symmetry.
-  void SetMirror(const gp_Pnt2d& theP);
+  void SetMirror(const gp_Pnt2d& theP) noexcept;
 
   //! Changes the transformation into a symmetrical transformation.
   //! theA is the center of the axial symmetry.
-  Standard_EXPORT void SetMirror(const gp_Ax2d& theA);
+  Standard_EXPORT void SetMirror(const gp_Ax2d& theA) noexcept;
 
   //! Changes the transformation into a rotation.
   //! theP is the rotation's center and theAng is the angular value of the
@@ -256,7 +256,7 @@ inline void gp_Trsf2d::SetRotation(const gp_Pnt2d& theP, const Standard_Real the
 
 //=================================================================================================
 
-inline void gp_Trsf2d::SetMirror(const gp_Pnt2d& theP)
+inline void gp_Trsf2d::SetMirror(const gp_Pnt2d& theP) noexcept
 {
   shape = gp_PntMirror;
   scale = -1.0;

--- a/src/FoundationClasses/TKMath/gp/gp_Vec2d.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Vec2d.cxx
@@ -103,7 +103,7 @@ gp_Vec2d gp_Vec2d::Mirrored(const gp_Ax2d& theA1) const
   return Vres;
 }
 
-void gp_Vec2d::Transform(const gp_Trsf2d& theT)
+void gp_Vec2d::Transform(const gp_Trsf2d& theT) noexcept
 {
   switch (theT.Form())
   {

--- a/src/FoundationClasses/TKMath/gp/gp_Vec2d.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Vec2d.hxx
@@ -339,7 +339,7 @@ public:
     return aV;
   }
 
-  Standard_EXPORT void Transform(const gp_Trsf2d& theT);
+  Standard_EXPORT void Transform(const gp_Trsf2d& theT) noexcept;
 
   //! Transforms a vector with a Trsf from gp.
   Standard_NODISCARD gp_Vec2d Transformed(const gp_Trsf2d& theT) const

--- a/src/ModelingAlgorithms/TKGeomAlgo/GeomInt/GeomInt_IntSS_1.cxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/GeomInt/GeomInt_IntSS_1.cxx
@@ -1077,7 +1077,6 @@ void GeomInt_IntSS::TreatRLine(const Handle(IntPatch_RLine)&      theRL,
   Handle(GeomAdaptor_Surface) aGAHS;
   Handle(Adaptor2d_Curve2d)   anAHC2d;
   Standard_Real               tf, tl;
-  gp_Lin2d                    aL;
   // It is assumed that 2d curve is 2d line (rectangular surface domain)
   if (theRL->IsArcOnS1())
   {


### PR DESCRIPTION
Annotate numerous gp 2D classes (gp_Pnt2d, gp_Vec2d, gp_Dir2d, gp_Ax2d, gp_Ax22d, gp_Lin2d, gp_Circ2d, gp_Elips2d, gp_Hypr2d, gp_Parab2d, gp_Trsf2d) with noexcept and add constexpr to trivial/constexpr-friendly accessors and constructors. Update corresponding inline/implementation functions to match. This documents no-throw guarantees and enables more compile-time evaluation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced exception-safety guarantees across geometric computation APIs, including transformation, mirroring, and translation operations for 2D geometry classes.
  * Improved internal state consistency for axis and point manipulation operations to ensure correct behavior across transformation methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->