### PR TITLE
Foundation Classes, gp - Mark geometry APIs noexcept/constexpr

### DIFF
--- a/src/FoundationClasses/TKMath/gp/gp_Ax1.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Ax1.cxx
@@ -43,39 +43,39 @@ Standard_Boolean gp_Ax1::IsCoaxial(const gp_Ax1&       Other,
           && D2 <= LinearTolerance);
 }
 
-void gp_Ax1::Mirror(const gp_Pnt& P)
+void gp_Ax1::Mirror(const gp_Pnt& P) noexcept
 {
   loc.Mirror(P);
   vdir.Reverse();
 }
 
-gp_Ax1 gp_Ax1::Mirrored(const gp_Pnt& P) const
+gp_Ax1 gp_Ax1::Mirrored(const gp_Pnt& P) const noexcept
 {
   gp_Ax1 A1 = *this;
   A1.Mirror(P);
   return A1;
 }
 
-void gp_Ax1::Mirror(const gp_Ax1& A1)
+void gp_Ax1::Mirror(const gp_Ax1& A1) noexcept
 {
   loc.Mirror(A1);
   vdir.Mirror(A1.vdir);
 }
 
-gp_Ax1 gp_Ax1::Mirrored(const gp_Ax1& A1) const
+gp_Ax1 gp_Ax1::Mirrored(const gp_Ax1& A1) const noexcept
 {
   gp_Ax1 A = *this;
   A.Mirror(A1);
   return A;
 }
 
-void gp_Ax1::Mirror(const gp_Ax2& A2)
+void gp_Ax1::Mirror(const gp_Ax2& A2) noexcept
 {
   loc.Mirror(A2);
   vdir.Mirror(A2);
 }
 
-gp_Ax1 gp_Ax1::Mirrored(const gp_Ax2& A2) const
+gp_Ax1 gp_Ax1::Mirrored(const gp_Ax2& A2) const noexcept
 {
   gp_Ax1 A1 = *this;
   A1.Mirror(A2);

--- a/src/FoundationClasses/TKMath/gp/gp_Ax1.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Ax1.hxx
@@ -118,34 +118,34 @@ public:
   //! Performs the symmetrical transformation of an axis
   //! placement with respect to the point P which is the
   //! center of the symmetry and assigns the result to this axis.
-  Standard_EXPORT void Mirror(const gp_Pnt& P);
+  Standard_EXPORT void Mirror(const gp_Pnt& P) noexcept;
 
   //! Performs the symmetrical transformation of an axis
   //! placement with respect to the point P which is the
   //! center of the symmetry and creates a new axis.
-  Standard_NODISCARD Standard_EXPORT gp_Ax1 Mirrored(const gp_Pnt& P) const;
+  Standard_NODISCARD Standard_EXPORT gp_Ax1 Mirrored(const gp_Pnt& P) const noexcept;
 
   //! Performs the symmetrical transformation of an axis
   //! placement with respect to an axis placement which
   //! is the axis of the symmetry and assigns the result to this axis.
-  Standard_EXPORT void Mirror(const gp_Ax1& A1);
+  Standard_EXPORT void Mirror(const gp_Ax1& A1) noexcept;
 
   //! Performs the symmetrical transformation of an axis
   //! placement with respect to an axis placement which
   //! is the axis of the symmetry and creates a new axis.
-  Standard_NODISCARD Standard_EXPORT gp_Ax1 Mirrored(const gp_Ax1& A1) const;
+  Standard_NODISCARD Standard_EXPORT gp_Ax1 Mirrored(const gp_Ax1& A1) const noexcept;
 
   //! Performs the symmetrical transformation of an axis
   //! placement with respect to a plane. The axis placement
   //! <A2> locates the plane of the symmetry :
   //! (Location, XDirection, YDirection) and assigns the result to this axis.
-  Standard_EXPORT void Mirror(const gp_Ax2& A2);
+  Standard_EXPORT void Mirror(const gp_Ax2& A2) noexcept;
 
   //! Performs the symmetrical transformation of an axis
   //! placement with respect to a plane. The axis placement
   //! <A2> locates the plane of the symmetry :
   //! (Location, XDirection, YDirection) and creates a new axis.
-  Standard_NODISCARD Standard_EXPORT gp_Ax1 Mirrored(const gp_Ax2& A2) const;
+  Standard_NODISCARD Standard_EXPORT gp_Ax1 Mirrored(const gp_Ax2& A2) const noexcept;
 
   //! Rotates this axis at an angle theAngRad (in radians) about the axis theA1
   //! and assigns the result to this axis.

--- a/src/FoundationClasses/TKMath/gp/gp_Ax2.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Ax2.cxx
@@ -74,7 +74,7 @@ gp_Ax2::gp_Ax2(const gp_Pnt& P, const gp_Dir& V)
   SetXDirection(D);
 }
 
-void gp_Ax2::Mirror(const gp_Pnt& P)
+void gp_Ax2::Mirror(const gp_Pnt& P) noexcept
 {
   gp_Pnt Temp = axis.Location();
   Temp.Mirror(P);
@@ -83,7 +83,7 @@ void gp_Ax2::Mirror(const gp_Pnt& P)
   vydir.Reverse();
 }
 
-gp_Ax2 gp_Ax2::Mirrored(const gp_Pnt& P) const
+gp_Ax2 gp_Ax2::Mirrored(const gp_Pnt& P) const noexcept
 {
   gp_Ax2 Temp = *this;
   Temp.Mirror(P);

--- a/src/FoundationClasses/TKMath/gp/gp_Ax2.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Ax2.hxx
@@ -181,7 +181,7 @@ public:
   //! product "X Direction" ^ "Y   Direction".
   //! This maintains the right-handed property of the
   //! coordinate system.
-  Standard_EXPORT void Mirror(const gp_Pnt& P);
+  Standard_EXPORT void Mirror(const gp_Pnt& P) noexcept;
 
   //! Performs a symmetrical transformation of this coordinate
   //! system with respect to:
@@ -198,7 +198,7 @@ public:
   //! product "X Direction" ^ "Y   Direction".
   //! This maintains the right-handed property of the
   //! coordinate system.
-  Standard_NODISCARD Standard_EXPORT gp_Ax2 Mirrored(const gp_Pnt& P) const;
+  Standard_NODISCARD Standard_EXPORT gp_Ax2 Mirrored(const gp_Pnt& P) const noexcept;
 
   //! Performs a symmetrical transformation of this coordinate
   //! system with respect to:

--- a/src/FoundationClasses/TKMath/gp/gp_Ax3.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Ax3.cxx
@@ -73,42 +73,42 @@ gp_Ax3::gp_Ax3(const gp_Pnt& P, const gp_Dir& V)
   vydir = V.Crossed(vxdir);
 }
 
-void gp_Ax3::Mirror(const gp_Pnt& P)
+void gp_Ax3::Mirror(const gp_Pnt& P) noexcept
 {
   axis.Mirror(P);
   vxdir.Reverse();
   vydir.Reverse();
 }
 
-gp_Ax3 gp_Ax3::Mirrored(const gp_Pnt& P) const
+gp_Ax3 gp_Ax3::Mirrored(const gp_Pnt& P) const noexcept
 {
   gp_Ax3 Temp = *this;
   Temp.Mirror(P);
   return Temp;
 }
 
-void gp_Ax3::Mirror(const gp_Ax1& A1)
+void gp_Ax3::Mirror(const gp_Ax1& A1) noexcept
 {
   vydir.Mirror(A1);
   vxdir.Mirror(A1);
   axis.Mirror(A1);
 }
 
-gp_Ax3 gp_Ax3::Mirrored(const gp_Ax1& A1) const
+gp_Ax3 gp_Ax3::Mirrored(const gp_Ax1& A1) const noexcept
 {
   gp_Ax3 Temp = *this;
   Temp.Mirror(A1);
   return Temp;
 }
 
-void gp_Ax3::Mirror(const gp_Ax2& A2)
+void gp_Ax3::Mirror(const gp_Ax2& A2) noexcept
 {
   vydir.Mirror(A2);
   vxdir.Mirror(A2);
   axis.Mirror(A2);
 }
 
-gp_Ax3 gp_Ax3::Mirrored(const gp_Ax2& A2) const
+gp_Ax3 gp_Ax3::Mirrored(const gp_Ax2& A2) const noexcept
 {
   gp_Ax3 Temp = *this;
   Temp.Mirror(A2);

--- a/src/FoundationClasses/TKMath/gp/gp_Ax3.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Ax3.hxx
@@ -200,7 +200,7 @@ public:
                               const Standard_Real theLinearTolerance,
                               const Standard_Real theAngularTolerance) const;
 
-  Standard_EXPORT void Mirror(const gp_Pnt& theP);
+  Standard_EXPORT void Mirror(const gp_Pnt& theP) noexcept;
 
   //! Performs the symmetrical transformation of an axis
   //! placement with respect to the point theP which is the
@@ -209,9 +209,9 @@ public:
   //! The main direction of the axis placement is not changed.
   //! The "XDirection" and the "YDirection" are reversed.
   //! So the axis placement stay right handed.
-  Standard_NODISCARD Standard_EXPORT gp_Ax3 Mirrored(const gp_Pnt& theP) const;
+  Standard_NODISCARD Standard_EXPORT gp_Ax3 Mirrored(const gp_Pnt& theP) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax1& theA1);
+  Standard_EXPORT void Mirror(const gp_Ax1& theA1) noexcept;
 
   //! Performs the symmetrical transformation of an axis
   //! placement with respect to an axis placement which
@@ -220,9 +220,9 @@ public:
   //! point, on the "XDirection" and "YDirection".
   //! The resulting main "Direction" is the cross product between
   //! the "XDirection" and the "YDirection" after transformation.
-  Standard_NODISCARD Standard_EXPORT gp_Ax3 Mirrored(const gp_Ax1& theA1) const;
+  Standard_NODISCARD Standard_EXPORT gp_Ax3 Mirrored(const gp_Ax1& theA1) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax2& theA2);
+  Standard_EXPORT void Mirror(const gp_Ax2& theA2) noexcept;
 
   //! Performs the symmetrical transformation of an axis
   //! placement with respect to a plane.
@@ -232,7 +232,7 @@ public:
   //! point, on the "XDirection" and "YDirection".
   //! The resulting main "Direction" is the cross product between
   //! the "XDirection" and the "YDirection" after transformation.
-  Standard_NODISCARD Standard_EXPORT gp_Ax3 Mirrored(const gp_Ax2& theA2) const;
+  Standard_NODISCARD Standard_EXPORT gp_Ax3 Mirrored(const gp_Ax2& theA2) const noexcept;
 
   void Rotate(const gp_Ax1& theA1, const Standard_Real theAng)
   {

--- a/src/FoundationClasses/TKMath/gp/gp_Circ.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Circ.cxx
@@ -18,12 +18,12 @@
 #include <gp_Ax2.hxx>
 #include <gp_Pnt.hxx>
 
-void gp_Circ::Mirror(const gp_Pnt& P)
+void gp_Circ::Mirror(const gp_Pnt& P) noexcept
 {
   pos.Mirror(P);
 }
 
-gp_Circ gp_Circ::Mirrored(const gp_Pnt& P) const
+gp_Circ gp_Circ::Mirrored(const gp_Pnt& P) const noexcept
 {
   gp_Circ C = *this;
   C.pos.Mirror(P);

--- a/src/FoundationClasses/TKMath/gp/gp_Circ.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Circ.hxx
@@ -145,7 +145,8 @@ public:
   //! Returns True if the point theP is on the circumference.
   //! The distance between <me> and <theP> must be lower or
   //! equal to theLinearTolerance.
-  Standard_Boolean Contains(const gp_Pnt& theP, const Standard_Real theLinearTolerance) const noexcept
+  Standard_Boolean Contains(const gp_Pnt&       theP,
+                            const Standard_Real theLinearTolerance) const noexcept
   {
     return Distance(theP) <= theLinearTolerance;
   }
@@ -207,7 +208,10 @@ public:
     return aC;
   }
 
-  constexpr void Translate(const gp_Pnt& theP1, const gp_Pnt& theP2) noexcept { pos.Translate(theP1, theP2); }
+  constexpr void Translate(const gp_Pnt& theP1, const gp_Pnt& theP2) noexcept
+  {
+    pos.Translate(theP1, theP2);
+  }
 
   //! Translates a circle from the point theP1 to the point theP2.
   Standard_NODISCARD gp_Circ Translated(const gp_Pnt& theP1, const gp_Pnt& theP2) const noexcept

--- a/src/FoundationClasses/TKMath/gp/gp_Circ.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Circ.hxx
@@ -78,10 +78,10 @@ public:
   void SetAxis(const gp_Ax1& theA1) { pos.SetAxis(theA1); }
 
   //! Changes the "Location" point (center) of the circle.
-  void SetLocation(const gp_Pnt& theP) { pos.SetLocation(theP); }
+  constexpr void SetLocation(const gp_Pnt& theP) noexcept { pos.SetLocation(theP); }
 
   //! Changes the position of the circle.
-  void SetPosition(const gp_Ax2& theA2) { pos = theA2; }
+  constexpr void SetPosition(const gp_Ax2& theA2) noexcept { pos = theA2; }
 
   //! Modifies the radius of this circle.
   //! Warning. This class does not prevent the creation of a circle where theRadius is null.
@@ -95,44 +95,44 @@ public:
   }
 
   //! Computes the area of the circle.
-  Standard_Real Area() const { return M_PI * radius * radius; }
+  constexpr Standard_Real Area() const noexcept { return M_PI * radius * radius; }
 
   //! Returns the main axis of the circle.
   //! It is the axis perpendicular to the plane of the circle,
   //! passing through the "Location" point (center) of the circle.
-  const gp_Ax1& Axis() const { return pos.Axis(); }
+  constexpr const gp_Ax1& Axis() const noexcept { return pos.Axis(); }
 
   //! Computes the circumference of the circle.
-  Standard_Real Length() const { return 2. * M_PI * radius; }
+  constexpr Standard_Real Length() const noexcept { return 2. * M_PI * radius; }
 
   //! Returns the center of the circle. It is the
   //! "Location" point of the local coordinate system
   //! of the circle
-  const gp_Pnt& Location() const { return pos.Location(); }
+  constexpr const gp_Pnt& Location() const noexcept { return pos.Location(); }
 
   //! Returns the position of the circle.
   //! It is the local coordinate system of the circle.
-  const gp_Ax2& Position() const { return pos; }
+  constexpr const gp_Ax2& Position() const noexcept { return pos; }
 
   //! Returns the radius of this circle.
-  Standard_Real Radius() const { return radius; }
+  constexpr Standard_Real Radius() const noexcept { return radius; }
 
   //! Returns the "XAxis" of the circle.
   //! This axis is perpendicular to the axis of the conic.
   //! This axis and the "Yaxis" define the plane of the conic.
-  gp_Ax1 XAxis() const { return gp_Ax1(pos.Location(), pos.XDirection()); }
+  constexpr gp_Ax1 XAxis() const noexcept { return gp_Ax1(pos.Location(), pos.XDirection()); }
 
   //! Returns the "YAxis" of the circle.
   //! This axis and the "Xaxis" define the plane of the conic.
   //! The "YAxis" is perpendicular to the "Xaxis".
-  gp_Ax1 YAxis() const { return gp_Ax1(pos.Location(), pos.YDirection()); }
+  constexpr gp_Ax1 YAxis() const noexcept { return gp_Ax1(pos.Location(), pos.YDirection()); }
 
   //! Computes the minimum of distance between the point theP and
   //! any point on the circumference of the circle.
-  Standard_Real Distance(const gp_Pnt& theP) const { return sqrt(SquareDistance(theP)); }
+  Standard_Real Distance(const gp_Pnt& theP) const noexcept { return sqrt(SquareDistance(theP)); }
 
   //! Computes the square distance between <me> and the point theP.
-  Standard_Real SquareDistance(const gp_Pnt& theP) const
+  Standard_Real SquareDistance(const gp_Pnt& theP) const noexcept
   {
     gp_Vec        aV(Location(), theP);
     Standard_Real aX  = aV.Dot(pos.XDirection());
@@ -145,17 +145,17 @@ public:
   //! Returns True if the point theP is on the circumference.
   //! The distance between <me> and <theP> must be lower or
   //! equal to theLinearTolerance.
-  Standard_Boolean Contains(const gp_Pnt& theP, const Standard_Real theLinearTolerance) const
+  Standard_Boolean Contains(const gp_Pnt& theP, const Standard_Real theLinearTolerance) const noexcept
   {
     return Distance(theP) <= theLinearTolerance;
   }
 
-  Standard_EXPORT void Mirror(const gp_Pnt& theP);
+  Standard_EXPORT void Mirror(const gp_Pnt& theP) noexcept;
 
   //! Performs the symmetrical transformation of a circle
   //! with respect to the point theP which is the center of the
   //! symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Circ Mirrored(const gp_Pnt& theP) const;
+  Standard_NODISCARD Standard_EXPORT gp_Circ Mirrored(const gp_Pnt& theP) const noexcept;
 
   Standard_EXPORT void Mirror(const gp_Ax1& theA1);
 
@@ -196,21 +196,21 @@ public:
   //! Transforms a circle with the transformation theT from class Trsf.
   Standard_NODISCARD gp_Circ Transformed(const gp_Trsf& theT) const;
 
-  void Translate(const gp_Vec& theV) { pos.Translate(theV); }
+  constexpr void Translate(const gp_Vec& theV) noexcept { pos.Translate(theV); }
 
   //! Translates a circle in the direction of the vector theV.
   //! The magnitude of the translation is the vector's magnitude.
-  Standard_NODISCARD gp_Circ Translated(const gp_Vec& theV) const
+  Standard_NODISCARD gp_Circ Translated(const gp_Vec& theV) const noexcept
   {
     gp_Circ aC = *this;
     aC.pos.Translate(theV);
     return aC;
   }
 
-  void Translate(const gp_Pnt& theP1, const gp_Pnt& theP2) { pos.Translate(theP1, theP2); }
+  constexpr void Translate(const gp_Pnt& theP1, const gp_Pnt& theP2) noexcept { pos.Translate(theP1, theP2); }
 
   //! Translates a circle from the point theP1 to the point theP2.
-  Standard_NODISCARD gp_Circ Translated(const gp_Pnt& theP1, const gp_Pnt& theP2) const
+  Standard_NODISCARD gp_Circ Translated(const gp_Pnt& theP1, const gp_Pnt& theP2) const noexcept
   {
     gp_Circ aC = *this;
     aC.pos.Translate(theP1, theP2);

--- a/src/FoundationClasses/TKMath/gp/gp_Cone.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Cone.cxx
@@ -63,36 +63,36 @@ void gp_Cone::Coefficients(Standard_Real& A1,
   D                  = T14 * T14 + T24 * T24 - radius * radius - T34 * T34 - 2.0 * radius * T34;
 }
 
-void gp_Cone::Mirror(const gp_Pnt& P)
+void gp_Cone::Mirror(const gp_Pnt& P) noexcept
 {
   pos.Mirror(P);
 }
 
-gp_Cone gp_Cone::Mirrored(const gp_Pnt& P) const
+gp_Cone gp_Cone::Mirrored(const gp_Pnt& P) const noexcept
 {
   gp_Cone C = *this;
   C.pos.Mirror(P);
   return C;
 }
 
-void gp_Cone::Mirror(const gp_Ax1& A1)
+void gp_Cone::Mirror(const gp_Ax1& A1) noexcept
 {
   pos.Mirror(A1);
 }
 
-gp_Cone gp_Cone::Mirrored(const gp_Ax1& A1) const
+gp_Cone gp_Cone::Mirrored(const gp_Ax1& A1) const noexcept
 {
   gp_Cone C = *this;
   C.pos.Mirror(A1);
   return C;
 }
 
-void gp_Cone::Mirror(const gp_Ax2& A2)
+void gp_Cone::Mirror(const gp_Ax2& A2) noexcept
 {
   pos.Mirror(A2);
 }
 
-gp_Cone gp_Cone::Mirrored(const gp_Ax2& A2) const
+gp_Cone gp_Cone::Mirrored(const gp_Ax2& A2) const noexcept
 {
   gp_Cone C = *this;
   C.pos.Mirror(A2);

--- a/src/FoundationClasses/TKMath/gp/gp_Cone.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Cone.hxx
@@ -77,11 +77,11 @@ public:
   void SetAxis(const gp_Ax1& theA1) { pos.SetAxis(theA1); }
 
   //! Changes the location of the cone.
-  void SetLocation(const gp_Pnt& theLoc) { pos.SetLocation(theLoc); }
+  constexpr void SetLocation(const gp_Pnt& theLoc) noexcept { pos.SetLocation(theLoc); }
 
   //! Changes the local coordinate system of the cone.
   //! This coordinate system defines the reference plane of the cone.
-  void SetPosition(const gp_Ax3& theA3) { pos = theA3; }
+  constexpr void SetPosition(const gp_Ax3& theA3) noexcept { pos = theA3; }
 
   //! Changes the radius of the cone in the reference plane of
   //! the cone.
@@ -122,10 +122,10 @@ public:
   }
 
   //! Returns true if the local coordinate system of this cone is right-handed.
-  Standard_Boolean Direct() const { return pos.Direct(); }
+  constexpr Standard_Boolean Direct() const noexcept { return pos.Direct(); }
 
   //! returns the symmetry axis of the cone.
-  const gp_Ax1& Axis() const { return pos.Axis(); }
+  constexpr const gp_Ax1& Axis() const noexcept { return pos.Axis(); }
 
   //! Computes the coefficients of the implicit equation of the quadric
   //! in the absolute cartesian coordinates system :
@@ -143,44 +143,44 @@ public:
                                     Standard_Real& theD) const;
 
   //! returns the "Location" point of the cone.
-  const gp_Pnt& Location() const { return pos.Location(); }
+  constexpr const gp_Pnt& Location() const noexcept { return pos.Location(); }
 
   //! Returns the local coordinates system of the cone.
-  const gp_Ax3& Position() const { return pos; }
+  constexpr const gp_Ax3& Position() const noexcept { return pos; }
 
   //! Returns the radius of the cone in the reference plane.
-  Standard_Real RefRadius() const { return radius; }
+  constexpr Standard_Real RefRadius() const noexcept { return radius; }
 
   //! Returns the half-angle at the apex of this cone.
   //! Attention! Semi-angle can be negative.
-  Standard_Real SemiAngle() const { return semiAngle; }
+  constexpr Standard_Real SemiAngle() const noexcept { return semiAngle; }
 
   //! Returns the XAxis of the reference plane.
-  gp_Ax1 XAxis() const { return gp_Ax1(pos.Location(), pos.XDirection()); }
+  constexpr gp_Ax1 XAxis() const noexcept { return gp_Ax1(pos.Location(), pos.XDirection()); }
 
   //! Returns the YAxis of the reference plane.
-  gp_Ax1 YAxis() const { return gp_Ax1(pos.Location(), pos.YDirection()); }
+  constexpr gp_Ax1 YAxis() const noexcept { return gp_Ax1(pos.Location(), pos.YDirection()); }
 
-  Standard_EXPORT void Mirror(const gp_Pnt& theP);
+  Standard_EXPORT void Mirror(const gp_Pnt& theP) noexcept;
 
   //! Performs the symmetrical transformation of a cone
   //! with respect to the point theP which is the center of the
   //! symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Cone Mirrored(const gp_Pnt& theP) const;
+  Standard_NODISCARD Standard_EXPORT gp_Cone Mirrored(const gp_Pnt& theP) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax1& theA1);
+  Standard_EXPORT void Mirror(const gp_Ax1& theA1) noexcept;
 
   //! Performs the symmetrical transformation of a cone with
   //! respect to an axis placement which is the axis of the
   //! symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Cone Mirrored(const gp_Ax1& theA1) const;
+  Standard_NODISCARD Standard_EXPORT gp_Cone Mirrored(const gp_Ax1& theA1) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax2& theA2);
+  Standard_EXPORT void Mirror(const gp_Ax2& theA2) noexcept;
 
   //! Performs the symmetrical transformation of a cone with respect
   //! to a plane. The axis placement theA2 locates the plane of the
   //! of the symmetry : (Location, XDirection, YDirection).
-  Standard_NODISCARD Standard_EXPORT gp_Cone Mirrored(const gp_Ax2& theA2) const;
+  Standard_NODISCARD Standard_EXPORT gp_Cone Mirrored(const gp_Ax2& theA2) const noexcept;
 
   void Rotate(const gp_Ax1& theA1, const Standard_Real theAng) { pos.Rotate(theA1, theAng); }
 
@@ -204,11 +204,11 @@ public:
   //! Transforms a cone with the transformation theT from class Trsf.
   Standard_NODISCARD gp_Cone Transformed(const gp_Trsf& theT) const;
 
-  void Translate(const gp_Vec& theV) { pos.Translate(theV); }
+  constexpr void Translate(const gp_Vec& theV) noexcept { pos.Translate(theV); }
 
   //! Translates a cone in the direction of the vector theV.
   //! The magnitude of the translation is the vector's magnitude.
-  Standard_NODISCARD gp_Cone Translated(const gp_Vec& theV) const
+  Standard_NODISCARD gp_Cone Translated(const gp_Vec& theV) const noexcept
   {
     gp_Cone aCone = *this;
     aCone.pos.Translate(theV);

--- a/src/FoundationClasses/TKMath/gp/gp_Cone.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Cone.hxx
@@ -112,17 +112,17 @@ public:
 
   //! Reverses the   U   parametrization of   the  cone
   //! reversing the YAxis.
-  void UReverse() { pos.YReverse(); }
+  constexpr void UReverse() noexcept { pos.YReverse(); }
 
   //! Reverses the   V   parametrization of   the  cone  reversing the ZAxis.
-  void VReverse()
+  constexpr void VReverse() noexcept
   {
     pos.ZReverse();
     semiAngle = -semiAngle;
   }
 
   //! Returns true if the local coordinate system of this cone is right-handed.
-  constexpr Standard_Boolean Direct() const noexcept { return pos.Direct(); }
+  Standard_Boolean Direct() const { return pos.Direct(); }
 
   //! returns the symmetry axis of the cone.
   constexpr const gp_Ax1& Axis() const noexcept { return pos.Axis(); }

--- a/src/FoundationClasses/TKMath/gp/gp_Cylinder.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Cylinder.cxx
@@ -60,36 +60,36 @@ void gp_Cylinder::Coefficients(Standard_Real& A1,
   D  = T14 * T14 + T24 * T24 - radius * radius;
 }
 
-void gp_Cylinder::Mirror(const gp_Pnt& P)
+void gp_Cylinder::Mirror(const gp_Pnt& P) noexcept
 {
   pos.Mirror(P);
 }
 
-gp_Cylinder gp_Cylinder::Mirrored(const gp_Pnt& P) const
+gp_Cylinder gp_Cylinder::Mirrored(const gp_Pnt& P) const noexcept
 {
   gp_Cylinder C = *this;
   C.pos.Mirror(P);
   return C;
 }
 
-void gp_Cylinder::Mirror(const gp_Ax1& A1)
+void gp_Cylinder::Mirror(const gp_Ax1& A1) noexcept
 {
   pos.Mirror(A1);
 }
 
-gp_Cylinder gp_Cylinder::Mirrored(const gp_Ax1& A1) const
+gp_Cylinder gp_Cylinder::Mirrored(const gp_Ax1& A1) const noexcept
 {
   gp_Cylinder C = *this;
   C.pos.Mirror(A1);
   return C;
 }
 
-void gp_Cylinder::Mirror(const gp_Ax2& A2)
+void gp_Cylinder::Mirror(const gp_Ax2& A2) noexcept
 {
   pos.Mirror(A2);
 }
 
-gp_Cylinder gp_Cylinder::Mirrored(const gp_Ax2& A2) const
+gp_Cylinder gp_Cylinder::Mirrored(const gp_Ax2& A2) const noexcept
 {
   gp_Cylinder C = *this;
   C.pos.Mirror(A2);

--- a/src/FoundationClasses/TKMath/gp/gp_Cylinder.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Cylinder.hxx
@@ -80,14 +80,14 @@ public:
 
   //! Reverses the   U   parametrization of   the cylinder
   //! reversing the YAxis.
-  void UReverse() { pos.YReverse(); }
+  constexpr void UReverse() noexcept { pos.YReverse(); }
 
   //! Reverses the   V   parametrization of   the  plane
   //! reversing the Axis.
-  void VReverse() { pos.ZReverse(); }
+  constexpr void VReverse() noexcept { pos.ZReverse(); }
 
   //! Returns true if the local coordinate system of this cylinder is right-handed.
-  constexpr Standard_Boolean Direct() const noexcept { return pos.Direct(); }
+  Standard_Boolean Direct() const { return pos.Direct(); }
 
   //! Returns the symmetry axis of the cylinder.
   constexpr const gp_Ax1& Axis() const noexcept { return pos.Axis(); }

--- a/src/FoundationClasses/TKMath/gp/gp_Cylinder.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Cylinder.hxx
@@ -62,10 +62,10 @@ public:
   void SetAxis(const gp_Ax1& theA1) { pos.SetAxis(theA1); }
 
   //! Changes the location of the surface.
-  void SetLocation(const gp_Pnt& theLoc) { pos.SetLocation(theLoc); }
+  constexpr void SetLocation(const gp_Pnt& theLoc) noexcept { pos.SetLocation(theLoc); }
 
   //! Change the local coordinate system of the surface.
-  void SetPosition(const gp_Ax3& theA3) { pos = theA3; }
+  constexpr void SetPosition(const gp_Ax3& theA3) noexcept { pos = theA3; }
 
   //! Modifies the radius of this cylinder.
   //! Exceptions
@@ -87,10 +87,10 @@ public:
   void VReverse() { pos.ZReverse(); }
 
   //! Returns true if the local coordinate system of this cylinder is right-handed.
-  Standard_Boolean Direct() const { return pos.Direct(); }
+  constexpr Standard_Boolean Direct() const noexcept { return pos.Direct(); }
 
   //! Returns the symmetry axis of the cylinder.
-  const gp_Ax1& Axis() const { return pos.Axis(); }
+  constexpr const gp_Ax1& Axis() const noexcept { return pos.Axis(); }
 
   //! Computes the coefficients of the implicit equation of the quadric
   //! in the absolute cartesian coordinate system :
@@ -108,40 +108,40 @@ public:
                                     Standard_Real& theD) const;
 
   //! Returns the "Location" point of the cylinder.
-  const gp_Pnt& Location() const { return pos.Location(); }
+  constexpr const gp_Pnt& Location() const noexcept { return pos.Location(); }
 
   //! Returns the local coordinate system of the cylinder.
-  const gp_Ax3& Position() const { return pos; }
+  constexpr const gp_Ax3& Position() const noexcept { return pos; }
 
   //! Returns the radius of the cylinder.
-  Standard_Real Radius() const { return radius; }
+  constexpr Standard_Real Radius() const noexcept { return radius; }
 
   //! Returns the axis X of the cylinder.
-  gp_Ax1 XAxis() const { return gp_Ax1(pos.Location(), pos.XDirection()); }
+  constexpr gp_Ax1 XAxis() const noexcept { return gp_Ax1(pos.Location(), pos.XDirection()); }
 
   //! Returns the axis Y of the cylinder.
-  gp_Ax1 YAxis() const { return gp_Ax1(pos.Location(), pos.YDirection()); }
+  constexpr gp_Ax1 YAxis() const noexcept { return gp_Ax1(pos.Location(), pos.YDirection()); }
 
-  Standard_EXPORT void Mirror(const gp_Pnt& theP);
+  Standard_EXPORT void Mirror(const gp_Pnt& theP) noexcept;
 
   //! Performs the symmetrical transformation of a cylinder
   //! with respect to the point theP which is the center of the
   //! symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Cylinder Mirrored(const gp_Pnt& theP) const;
+  Standard_NODISCARD Standard_EXPORT gp_Cylinder Mirrored(const gp_Pnt& theP) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax1& theA1);
+  Standard_EXPORT void Mirror(const gp_Ax1& theA1) noexcept;
 
   //! Performs the symmetrical transformation of a cylinder with
   //! respect to an axis placement which is the axis of the
   //! symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Cylinder Mirrored(const gp_Ax1& theA1) const;
+  Standard_NODISCARD Standard_EXPORT gp_Cylinder Mirrored(const gp_Ax1& theA1) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax2& theA2);
+  Standard_EXPORT void Mirror(const gp_Ax2& theA2) noexcept;
 
   //! Performs the symmetrical transformation of a cylinder with respect
   //! to a plane. The axis placement theA2 locates the plane of the
   //! of the symmetry : (Location, XDirection, YDirection).
-  Standard_NODISCARD Standard_EXPORT gp_Cylinder Mirrored(const gp_Ax2& theA2) const;
+  Standard_NODISCARD Standard_EXPORT gp_Cylinder Mirrored(const gp_Ax2& theA2) const noexcept;
 
   void Rotate(const gp_Ax1& theA1, const Standard_Real theAng) { pos.Rotate(theA1, theAng); }
 
@@ -165,11 +165,11 @@ public:
   //! Transforms a cylinder with the transformation theT from class Trsf.
   Standard_NODISCARD gp_Cylinder Transformed(const gp_Trsf& theT) const;
 
-  void Translate(const gp_Vec& theV) { pos.Translate(theV); }
+  constexpr void Translate(const gp_Vec& theV) noexcept { pos.Translate(theV); }
 
   //! Translates a cylinder in the direction of the vector theV.
   //! The magnitude of the translation is the vector's magnitude.
-  Standard_NODISCARD gp_Cylinder Translated(const gp_Vec& theV) const
+  Standard_NODISCARD gp_Cylinder Translated(const gp_Vec& theV) const noexcept
   {
     gp_Cylinder aCyl = *this;
     aCyl.pos.Translate(theV);

--- a/src/FoundationClasses/TKMath/gp/gp_Dir.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Dir.cxx
@@ -67,7 +67,7 @@ Standard_Real gp_Dir::AngleWithRef(const gp_Dir& Other, const gp_Dir& Vref) cons
     return -Ang;
 }
 
-void gp_Dir::Mirror(const gp_Dir& V)
+void gp_Dir::Mirror(const gp_Dir& V) noexcept
 {
   const gp_XYZ& XYZ = V.coord;
   Standard_Real A   = XYZ.X();
@@ -85,7 +85,7 @@ void gp_Dir::Mirror(const gp_Dir& V)
   coord.SetCoord(XX, YY, ZZ);
 }
 
-void gp_Dir::Mirror(const gp_Ax1& A1)
+void gp_Dir::Mirror(const gp_Ax1& A1) noexcept
 {
   const gp_XYZ& XYZ = A1.Direction().coord;
   Standard_Real A   = XYZ.X();
@@ -103,7 +103,7 @@ void gp_Dir::Mirror(const gp_Ax1& A1)
   coord.SetCoord(XX, YY, ZZ);
 }
 
-void gp_Dir::Mirror(const gp_Ax2& A2)
+void gp_Dir::Mirror(const gp_Ax2& A2) noexcept
 {
   const gp_Dir& Vz = A2.Direction();
   Mirror(Vz);
@@ -138,21 +138,21 @@ void gp_Dir::Transform(const gp_Trsf& T)
   }
 }
 
-gp_Dir gp_Dir::Mirrored(const gp_Dir& V) const
+gp_Dir gp_Dir::Mirrored(const gp_Dir& V) const noexcept
 {
   gp_Dir Vres = *this;
   Vres.Mirror(V);
   return Vres;
 }
 
-gp_Dir gp_Dir::Mirrored(const gp_Ax1& A1) const
+gp_Dir gp_Dir::Mirrored(const gp_Ax1& A1) const noexcept
 {
   gp_Dir V = *this;
   V.Mirror(A1);
   return V;
 }
 
-gp_Dir gp_Dir::Mirrored(const gp_Ax2& A2) const
+gp_Dir gp_Dir::Mirrored(const gp_Ax2& A2) const noexcept
 {
   gp_Dir V = *this;
   V.Mirror(A2);

--- a/src/FoundationClasses/TKMath/gp/gp_Dir.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Dir.hxx
@@ -235,26 +235,26 @@ public:
 
   Standard_NODISCARD constexpr gp_Dir operator-() const noexcept { return Reversed(); }
 
-  Standard_EXPORT void Mirror(const gp_Dir& theV);
+  Standard_EXPORT void Mirror(const gp_Dir& theV) noexcept;
 
   //! Performs the symmetrical transformation of a direction
   //! with respect to the direction theV which is the center
   //! of the symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Dir Mirrored(const gp_Dir& theV) const;
+  Standard_NODISCARD Standard_EXPORT gp_Dir Mirrored(const gp_Dir& theV) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax1& theA1);
+  Standard_EXPORT void Mirror(const gp_Ax1& theA1) noexcept;
 
   //! Performs the symmetrical transformation of a direction
   //! with respect to an axis placement which is the axis
   //! of the symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Dir Mirrored(const gp_Ax1& theA1) const;
+  Standard_NODISCARD Standard_EXPORT gp_Dir Mirrored(const gp_Ax1& theA1) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax2& theA2);
+  Standard_EXPORT void Mirror(const gp_Ax2& theA2) noexcept;
 
   //! Performs the symmetrical transformation of a direction
   //! with respect to a plane. The axis placement theA2 locates
   //! the plane of the symmetry : (Location, XDirection, YDirection).
-  Standard_NODISCARD Standard_EXPORT gp_Dir Mirrored(const gp_Ax2& theA2) const;
+  Standard_NODISCARD Standard_EXPORT gp_Dir Mirrored(const gp_Ax2& theA2) const noexcept;
 
   void Rotate(const gp_Ax1& theA1, const Standard_Real theAng);
 

--- a/src/FoundationClasses/TKMath/gp/gp_Elips.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Elips.cxx
@@ -20,12 +20,12 @@
 #include <gp_Ax2.hxx>
 #include <gp_Pnt.hxx>
 
-void gp_Elips::Mirror(const gp_Pnt& P)
+void gp_Elips::Mirror(const gp_Pnt& P) noexcept
 {
   pos.Mirror(P);
 }
 
-gp_Elips gp_Elips::Mirrored(const gp_Pnt& P) const
+gp_Elips gp_Elips::Mirrored(const gp_Pnt& P) const noexcept
 {
   gp_Elips E = *this;
   E.pos.Mirror(P);

--- a/src/FoundationClasses/TKMath/gp/gp_Elips.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Elips.hxx
@@ -247,7 +247,10 @@ public:
     return anE;
   }
 
-  constexpr void Translate(const gp_Pnt& theP1, const gp_Pnt& theP2) noexcept { pos.Translate(theP1, theP2); }
+  constexpr void Translate(const gp_Pnt& theP1, const gp_Pnt& theP2) noexcept
+  {
+    pos.Translate(theP1, theP2);
+  }
 
   //! Translates an ellipse from the point theP1 to the point theP2.
   Standard_NODISCARD gp_Elips Translated(const gp_Pnt& theP1, const gp_Pnt& theP2) const noexcept

--- a/src/FoundationClasses/TKMath/gp/gp_Elips.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Elips.hxx
@@ -90,7 +90,7 @@ public:
 
   //! Modifies this ellipse, by redefining its local coordinate
   //! so that its origin becomes theP.
-  void SetLocation(const gp_Pnt& theP) { pos.SetLocation(theP); }
+  constexpr void SetLocation(const gp_Pnt& theP) noexcept { pos.SetLocation(theP); }
 
   //! The major radius of the ellipse is on the "XAxis" (major axis)
   //! of the ellipse.
@@ -116,13 +116,13 @@ public:
 
   //! Modifies this ellipse, by redefining its local coordinate
   //! so that it becomes theA2.
-  void SetPosition(const gp_Ax2& theA2) { pos = theA2; }
+  constexpr void SetPosition(const gp_Ax2& theA2) noexcept { pos = theA2; }
 
   //! Computes the area of the Ellipse.
-  Standard_Real Area() const { return M_PI * majorRadius * minorRadius; }
+  constexpr Standard_Real Area() const noexcept { return M_PI * majorRadius * minorRadius; }
 
   //! Computes the axis normal to the plane of the ellipse.
-  const gp_Ax1& Axis() const { return pos.Axis(); }
+  constexpr const gp_Ax1& Axis() const noexcept { return pos.Axis(); }
 
   //! Computes the first or second directrix of this ellipse.
   //! These are the lines, in the plane of the ellipse, normal to
@@ -170,13 +170,13 @@ public:
 
   //! Returns the center of the ellipse. It is the "Location"
   //! point of the coordinate system of the ellipse.
-  const gp_Pnt& Location() const { return pos.Location(); }
+  constexpr const gp_Pnt& Location() const noexcept { return pos.Location(); }
 
   //! Returns the major radius of the ellipse.
-  Standard_Real MajorRadius() const { return majorRadius; }
+  constexpr Standard_Real MajorRadius() const noexcept { return majorRadius; }
 
   //! Returns the minor radius of the ellipse.
-  Standard_Real MinorRadius() const { return minorRadius; }
+  constexpr Standard_Real MinorRadius() const noexcept { return minorRadius; }
 
   //! Returns p = (1 - e * e) * MajorRadius where e is the eccentricity
   //! of the ellipse.
@@ -184,23 +184,23 @@ public:
   Standard_Real Parameter() const;
 
   //! Returns the coordinate system of the ellipse.
-  const gp_Ax2& Position() const { return pos; }
+  constexpr const gp_Ax2& Position() const noexcept { return pos; }
 
   //! Returns the "XAxis" of the ellipse whose origin
   //! is the center of this ellipse. It is the major axis of the
   //! ellipse.
-  gp_Ax1 XAxis() const { return gp_Ax1(pos.Location(), pos.XDirection()); }
+  constexpr gp_Ax1 XAxis() const noexcept { return gp_Ax1(pos.Location(), pos.XDirection()); }
 
   //! Returns the "YAxis" of the ellipse whose unit vector is the "X Direction" or the "Y Direction"
   //! of the local coordinate system of this ellipse.
   //! This is the minor axis of the ellipse.
-  gp_Ax1 YAxis() const { return gp_Ax1(pos.Location(), pos.YDirection()); }
+  constexpr gp_Ax1 YAxis() const noexcept { return gp_Ax1(pos.Location(), pos.YDirection()); }
 
-  Standard_EXPORT void Mirror(const gp_Pnt& theP);
+  Standard_EXPORT void Mirror(const gp_Pnt& theP) noexcept;
 
   //! Performs the symmetrical transformation of an ellipse with
   //! respect to the point theP which is the center of the symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Elips Mirrored(const gp_Pnt& theP) const;
+  Standard_NODISCARD Standard_EXPORT gp_Elips Mirrored(const gp_Pnt& theP) const noexcept;
 
   Standard_EXPORT void Mirror(const gp_Ax1& theA1);
 
@@ -236,21 +236,21 @@ public:
   //! Transforms an ellipse with the transformation theT from class Trsf.
   Standard_NODISCARD gp_Elips Transformed(const gp_Trsf& theT) const;
 
-  void Translate(const gp_Vec& theV) { pos.Translate(theV); }
+  constexpr void Translate(const gp_Vec& theV) noexcept { pos.Translate(theV); }
 
   //! Translates an ellipse in the direction of the vector theV.
   //! The magnitude of the translation is the vector's magnitude.
-  Standard_NODISCARD gp_Elips Translated(const gp_Vec& theV) const
+  Standard_NODISCARD gp_Elips Translated(const gp_Vec& theV) const noexcept
   {
     gp_Elips anE = *this;
     anE.pos.Translate(theV);
     return anE;
   }
 
-  void Translate(const gp_Pnt& theP1, const gp_Pnt& theP2) { pos.Translate(theP1, theP2); }
+  constexpr void Translate(const gp_Pnt& theP1, const gp_Pnt& theP2) noexcept { pos.Translate(theP1, theP2); }
 
   //! Translates an ellipse from the point theP1 to the point theP2.
-  Standard_NODISCARD gp_Elips Translated(const gp_Pnt& theP1, const gp_Pnt& theP2) const
+  Standard_NODISCARD gp_Elips Translated(const gp_Pnt& theP1, const gp_Pnt& theP2) const noexcept
   {
     gp_Elips anE = *this;
     anE.pos.Translate(theP1, theP2);

--- a/src/FoundationClasses/TKMath/gp/gp_Hypr.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Hypr.cxx
@@ -20,12 +20,12 @@
 #include <gp_Ax2.hxx>
 #include <gp_Pnt.hxx>
 
-void gp_Hypr::Mirror(const gp_Pnt& P)
+void gp_Hypr::Mirror(const gp_Pnt& P) noexcept
 {
   pos.Mirror(P);
 }
 
-gp_Hypr gp_Hypr::Mirrored(const gp_Pnt& P) const
+gp_Hypr gp_Hypr::Mirrored(const gp_Pnt& P) const noexcept
 {
   gp_Hypr H = *this;
   H.pos.Mirror(P);

--- a/src/FoundationClasses/TKMath/gp/gp_Hypr.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Hypr.hxx
@@ -146,7 +146,7 @@ public:
 
   //! Modifies this hyperbola, by redefining its local coordinate
   //! system so that it becomes A2.
-  void SetPosition(const gp_Ax2& theA2) { pos = theA2; }
+  constexpr void SetPosition(const gp_Ax2& theA2) noexcept { pos = theA2; }
 
   //! In the local coordinate system of the hyperbola the equation of
   //! the hyperbola is (X*X)/(A*A) - (Y*Y)/(B*B) = 1.0 and the
@@ -164,7 +164,7 @@ public:
 
   //! Returns the axis passing through the center,
   //! and normal to the plane of this hyperbola.
-  const gp_Ax1& Axis() const { return pos.Axis(); }
+  constexpr const gp_Ax1& Axis() const noexcept { return pos.Axis(); }
 
   //! Computes the branch of hyperbola which is on the positive side of the
   //! "YAxis" of <me>.
@@ -211,7 +211,7 @@ public:
 
   //! Computes the focal distance. It is the distance between the
   //! the two focus of the hyperbola.
-  Standard_Real Focal() const
+  constexpr Standard_Real Focal() const noexcept
   {
     return 2.0 * sqrt(majorRadius * majorRadius + minorRadius * minorRadius);
   }
@@ -226,15 +226,15 @@ public:
 
   //! Returns the location point of the hyperbola. It is the
   //! intersection point between the "XAxis" and the "YAxis".
-  const gp_Pnt& Location() const { return pos.Location(); }
+  constexpr const gp_Pnt& Location() const noexcept { return pos.Location(); }
 
   //! Returns the major radius of the hyperbola. It is the radius
   //! on the "XAxis" of the hyperbola.
-  Standard_Real MajorRadius() const { return majorRadius; }
+  constexpr Standard_Real MajorRadius() const noexcept { return majorRadius; }
 
   //! Returns the minor radius of the hyperbola. It is the radius
   //! on the "YAxis" of the hyperbola.
-  Standard_Real MinorRadius() const { return minorRadius; }
+  constexpr Standard_Real MinorRadius() const noexcept { return minorRadius; }
 
   //! Returns the branch of hyperbola obtained by doing the
   //! symmetrical transformation of <me> with respect to the
@@ -257,7 +257,7 @@ public:
   }
 
   //! Returns the coordinate system of the hyperbola.
-  const gp_Ax2& Position() const { return pos; }
+  constexpr const gp_Ax2& Position() const noexcept { return pos; }
 
   //! Computes an axis, whose
   //! -   the origin is the center of this hyperbola, and
@@ -265,20 +265,20 @@ public:
   //! of the local coordinate system of this hyperbola.
   //! These axes are, the major axis (the "X
   //! Axis") and  of this hyperboReturns the "XAxis" of the hyperbola.
-  gp_Ax1 XAxis() const { return gp_Ax1(pos.Location(), pos.XDirection()); }
+  constexpr gp_Ax1 XAxis() const noexcept { return gp_Ax1(pos.Location(), pos.XDirection()); }
 
   //! Computes an axis, whose
   //! -   the origin is the center of this hyperbola, and
   //! -   the unit vector is the "Y Direction"
   //! of the local coordinate system of this hyperbola.
   //! These axes are the minor axis (the "Y Axis") of this hyperbola
-  gp_Ax1 YAxis() const { return gp_Ax1(pos.Location(), pos.YDirection()); }
+  constexpr gp_Ax1 YAxis() const noexcept { return gp_Ax1(pos.Location(), pos.YDirection()); }
 
-  Standard_EXPORT void Mirror(const gp_Pnt& theP);
+  Standard_EXPORT void Mirror(const gp_Pnt& theP) noexcept;
 
   //! Performs the symmetrical transformation of an hyperbola with
   //! respect to the point theP which is the center of the symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Hypr Mirrored(const gp_Pnt& theP) const;
+  Standard_NODISCARD Standard_EXPORT gp_Hypr Mirrored(const gp_Pnt& theP) const noexcept;
 
   Standard_EXPORT void Mirror(const gp_Ax1& theA1);
 
@@ -315,21 +315,21 @@ public:
   //! class Trsf.
   Standard_NODISCARD gp_Hypr Transformed(const gp_Trsf& theT) const;
 
-  void Translate(const gp_Vec& theV) { pos.Translate(theV); }
+  constexpr void Translate(const gp_Vec& theV) noexcept { pos.Translate(theV); }
 
   //! Translates an hyperbola in the direction of the vector theV.
   //! The magnitude of the translation is the vector's magnitude.
-  Standard_NODISCARD gp_Hypr Translated(const gp_Vec& theV) const
+  Standard_NODISCARD gp_Hypr Translated(const gp_Vec& theV) const noexcept
   {
     gp_Hypr aH = *this;
     aH.pos.Translate(theV);
     return aH;
   }
 
-  void Translate(const gp_Pnt& theP1, const gp_Pnt& theP2) { pos.Translate(theP1, theP2); }
+  constexpr void Translate(const gp_Pnt& theP1, const gp_Pnt& theP2) noexcept { pos.Translate(theP1, theP2); }
 
   //! Translates an hyperbola from the point theP1 to the point theP2.
-  Standard_NODISCARD gp_Hypr Translated(const gp_Pnt& theP1, const gp_Pnt& theP2) const
+  Standard_NODISCARD gp_Hypr Translated(const gp_Pnt& theP1, const gp_Pnt& theP2) const noexcept
   {
     gp_Hypr aH = *this;
     aH.pos.Translate(theP1, theP2);

--- a/src/FoundationClasses/TKMath/gp/gp_Hypr.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Hypr.hxx
@@ -211,7 +211,7 @@ public:
 
   //! Computes the focal distance. It is the distance between the
   //! the two focus of the hyperbola.
-  constexpr Standard_Real Focal() const noexcept
+  Standard_Real Focal() const noexcept
   {
     return 2.0 * sqrt(majorRadius * majorRadius + minorRadius * minorRadius);
   }

--- a/src/FoundationClasses/TKMath/gp/gp_Hypr.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Hypr.hxx
@@ -326,7 +326,10 @@ public:
     return aH;
   }
 
-  constexpr void Translate(const gp_Pnt& theP1, const gp_Pnt& theP2) noexcept { pos.Translate(theP1, theP2); }
+  constexpr void Translate(const gp_Pnt& theP1, const gp_Pnt& theP2) noexcept
+  {
+    pos.Translate(theP1, theP2);
+  }
 
   //! Translates an hyperbola from the point theP1 to the point theP2.
   Standard_NODISCARD gp_Hypr Translated(const gp_Pnt& theP1, const gp_Pnt& theP2) const noexcept

--- a/src/FoundationClasses/TKMath/gp/gp_Lin.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Lin.cxx
@@ -41,36 +41,36 @@ Standard_Real gp_Lin::Distance(const gp_Lin& Other) const
   }
 }
 
-void gp_Lin::Mirror(const gp_Pnt& P)
+void gp_Lin::Mirror(const gp_Pnt& P) noexcept
 {
   pos.Mirror(P);
 }
 
-gp_Lin gp_Lin::Mirrored(const gp_Pnt& P) const
+gp_Lin gp_Lin::Mirrored(const gp_Pnt& P) const noexcept
 {
   gp_Lin L = *this;
   L.pos.Mirror(P);
   return L;
 }
 
-void gp_Lin::Mirror(const gp_Ax1& A1)
+void gp_Lin::Mirror(const gp_Ax1& A1) noexcept
 {
   pos.Mirror(A1);
 }
 
-gp_Lin gp_Lin::Mirrored(const gp_Ax1& A1) const
+gp_Lin gp_Lin::Mirrored(const gp_Ax1& A1) const noexcept
 {
   gp_Lin L = *this;
   L.pos.Mirror(A1);
   return L;
 }
 
-void gp_Lin::Mirror(const gp_Ax2& A2)
+void gp_Lin::Mirror(const gp_Ax2& A2) noexcept
 {
   pos.Mirror(A2);
 }
 
-gp_Lin gp_Lin::Mirrored(const gp_Ax2& A2) const
+gp_Lin gp_Lin::Mirrored(const gp_Ax2& A2) const noexcept
 {
   gp_Lin L = *this;
   L.pos.Mirror(A2);

--- a/src/FoundationClasses/TKMath/gp/gp_Lin.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Lin.hxx
@@ -73,28 +73,28 @@ public:
   }
 
   //! Changes the direction of the line.
-  void SetDirection(const gp_Dir& theV) { pos.SetDirection(theV); }
+  constexpr void SetDirection(const gp_Dir& theV) noexcept { pos.SetDirection(theV); }
 
   //! Changes the location point (origin) of the line.
-  void SetLocation(const gp_Pnt& theP) { pos.SetLocation(theP); }
+  constexpr void SetLocation(const gp_Pnt& theP) noexcept { pos.SetLocation(theP); }
 
   //! Complete redefinition of the line.
   //! The "Location" point of <theA1> is the origin of the line.
   //! The "Direction" of <theA1> is  the direction of the line.
-  void SetPosition(const gp_Ax1& theA1) { pos = theA1; }
+  constexpr void SetPosition(const gp_Ax1& theA1) noexcept { pos = theA1; }
 
   //! Returns the direction of the line.
-  const gp_Dir& Direction() const { return pos.Direction(); }
+  constexpr const gp_Dir& Direction() const noexcept { return pos.Direction(); }
 
   //! Returns the location point (origin) of the line.
-  const gp_Pnt& Location() const { return pos.Location(); }
+  constexpr const gp_Pnt& Location() const noexcept { return pos.Location(); }
 
   //! Returns the axis placement one axis with the same
   //! location and direction as <me>.
-  const gp_Ax1& Position() const { return pos; }
+  constexpr const gp_Ax1& Position() const noexcept { return pos; }
 
   //! Computes the angle between two lines in radians.
-  Standard_Real Angle(const gp_Lin& theOther) const
+  Standard_Real Angle(const gp_Lin& theOther) const noexcept
   {
     return pos.Direction().Angle(theOther.pos.Direction());
   }
@@ -102,22 +102,22 @@ public:
   //! Returns true if this line contains the point theP, that is, if the
   //! distance between point theP and this line is less than or
   //! equal to theLinearTolerance..
-  Standard_Boolean Contains(const gp_Pnt& theP, const Standard_Real theLinearTolerance) const
+  Standard_Boolean Contains(const gp_Pnt& theP, const Standard_Real theLinearTolerance) const noexcept
   {
     return Distance(theP) <= theLinearTolerance;
   }
 
   //! Computes the distance between <me> and the point theP.
-  Standard_Real Distance(const gp_Pnt& theP) const;
+  Standard_Real Distance(const gp_Pnt& theP) const noexcept;
 
   //! Computes the distance between two lines.
   Standard_EXPORT Standard_Real Distance(const gp_Lin& theOther) const;
 
   //! Computes the square distance between <me> and the point theP.
-  Standard_Real SquareDistance(const gp_Pnt& theP) const;
+  Standard_Real SquareDistance(const gp_Pnt& theP) const noexcept;
 
   //! Computes the square distance between two lines.
-  Standard_Real SquareDistance(const gp_Lin& theOther) const
+  Standard_Real SquareDistance(const gp_Lin& theOther) const noexcept
   {
     Standard_Real aD = Distance(theOther);
     return aD * aD;
@@ -130,27 +130,27 @@ public:
   //! solutions in 3D space.
   gp_Lin Normal(const gp_Pnt& theP) const;
 
-  Standard_EXPORT void Mirror(const gp_Pnt& theP);
+  Standard_EXPORT void Mirror(const gp_Pnt& theP) noexcept;
 
   //! Performs the symmetrical transformation of a line
   //! with respect to the point theP which is the center of
   //! the symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Lin Mirrored(const gp_Pnt& theP) const;
+  Standard_NODISCARD Standard_EXPORT gp_Lin Mirrored(const gp_Pnt& theP) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax1& theA1);
+  Standard_EXPORT void Mirror(const gp_Ax1& theA1) noexcept;
 
   //! Performs the symmetrical transformation of a line
   //! with respect to an axis placement which is the axis
   //! of the symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Lin Mirrored(const gp_Ax1& theA1) const;
+  Standard_NODISCARD Standard_EXPORT gp_Lin Mirrored(const gp_Ax1& theA1) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax2& theA2);
+  Standard_EXPORT void Mirror(const gp_Ax2& theA2) noexcept;
 
   //! Performs the symmetrical transformation of a line
   //! with respect to a plane. The axis placement  <theA2>
   //! locates the plane of the symmetry :
   //! (Location, XDirection, YDirection).
-  Standard_NODISCARD Standard_EXPORT gp_Lin Mirrored(const gp_Ax2& theA2) const;
+  Standard_NODISCARD Standard_EXPORT gp_Lin Mirrored(const gp_Ax2& theA2) const noexcept;
 
   void Rotate(const gp_Ax1& theA1, const Standard_Real theAng) { pos.Rotate(theA1, theAng); }
 
@@ -185,11 +185,11 @@ public:
     return aL;
   }
 
-  void Translate(const gp_Vec& theV) { pos.Translate(theV); }
+  constexpr void Translate(const gp_Vec& theV) noexcept { pos.Translate(theV); }
 
   //! Translates a line in the direction of the vector theV.
   //! The magnitude of the translation is the vector's magnitude.
-  Standard_NODISCARD gp_Lin Translated(const gp_Vec& theV) const
+  Standard_NODISCARD gp_Lin Translated(const gp_Vec& theV) const noexcept
   {
     gp_Lin aL = *this;
     aL.pos.Translate(theV);
@@ -212,7 +212,7 @@ private:
 
 //=================================================================================================
 
-inline Standard_Real gp_Lin::Distance(const gp_Pnt& theP) const
+inline Standard_Real gp_Lin::Distance(const gp_Pnt& theP) const noexcept
 {
   gp_XYZ aCoord = theP.XYZ();
   aCoord.Subtract((pos.Location()).XYZ());
@@ -222,7 +222,7 @@ inline Standard_Real gp_Lin::Distance(const gp_Pnt& theP) const
 
 //=================================================================================================
 
-inline Standard_Real gp_Lin::SquareDistance(const gp_Pnt& theP) const
+inline Standard_Real gp_Lin::SquareDistance(const gp_Pnt& theP) const noexcept
 {
   const gp_Pnt& aLoc = pos.Location();
   gp_Vec        aV(theP.X() - aLoc.X(), theP.Y() - aLoc.Y(), theP.Z() - aLoc.Z());

--- a/src/FoundationClasses/TKMath/gp/gp_Lin.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Lin.hxx
@@ -102,7 +102,8 @@ public:
   //! Returns true if this line contains the point theP, that is, if the
   //! distance between point theP and this line is less than or
   //! equal to theLinearTolerance..
-  Standard_Boolean Contains(const gp_Pnt& theP, const Standard_Real theLinearTolerance) const noexcept
+  Standard_Boolean Contains(const gp_Pnt&       theP,
+                            const Standard_Real theLinearTolerance) const noexcept
   {
     return Distance(theP) <= theLinearTolerance;
   }

--- a/src/FoundationClasses/TKMath/gp/gp_Mat.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Mat.cxx
@@ -99,7 +99,7 @@ void gp_Mat::SetCross(const gp_XYZ& theRef)
 
 //=================================================================================================
 
-void gp_Mat::SetDot(const gp_XYZ& theRef)
+void gp_Mat::SetDot(const gp_XYZ& theRef) noexcept
 {
   const Standard_Real X = theRef.X();
   const Standard_Real Y = theRef.Y();

--- a/src/FoundationClasses/TKMath/gp/gp_Mat.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Mat.hxx
@@ -89,7 +89,7 @@ public:
   //! product of theRef and the number triple (X, Y, Z):
   //! this * (X,Y,Z) = theRef.(X,Y,Z)
   //! Note: this matrix is symmetric.
-  Standard_EXPORT void SetDot(const gp_XYZ& theRef);
+  Standard_EXPORT void SetDot(const gp_XYZ& theRef) noexcept;
 
   //! Modifies this matrix so that it represents the Identity matrix.
   constexpr void SetIdentity() noexcept

--- a/src/FoundationClasses/TKMath/gp/gp_Parab.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Parab.cxx
@@ -20,12 +20,12 @@
 #include <gp_Ax2.hxx>
 #include <gp_Pnt.hxx>
 
-void gp_Parab::Mirror(const gp_Pnt& P)
+void gp_Parab::Mirror(const gp_Pnt& P) noexcept
 {
   pos.Mirror(P);
 }
 
-gp_Parab gp_Parab::Mirrored(const gp_Pnt& P) const
+gp_Parab gp_Parab::Mirrored(const gp_Pnt& P) const noexcept
 {
   gp_Parab Prb = *this;
   Prb.pos.Mirror(P);

--- a/src/FoundationClasses/TKMath/gp/gp_Parab.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Parab.hxx
@@ -102,15 +102,15 @@ public:
 
   //! Changes the location of the parabola. It is the vertex of
   //! the parabola.
-  void SetLocation(const gp_Pnt& theP) { pos.SetLocation(theP); }
+  constexpr void SetLocation(const gp_Pnt& theP) noexcept { pos.SetLocation(theP); }
 
   //! Changes the local coordinate system of the parabola.
-  void SetPosition(const gp_Ax2& theA2) { pos = theA2; }
+  constexpr void SetPosition(const gp_Ax2& theA2) noexcept { pos = theA2; }
 
   //! Returns the main axis of the parabola.
   //! It is the axis normal to the plane of the parabola passing
   //! through the vertex of the parabola.
-  const gp_Ax1& Axis() const { return pos.Axis(); }
+  constexpr const gp_Ax1& Axis() const noexcept { return pos.Axis(); }
 
   //! Computes the directrix of this parabola.
   //! The directrix is:
@@ -125,37 +125,37 @@ public:
 
   //! Returns the distance between the vertex and the focus
   //! of the parabola.
-  Standard_Real Focal() const { return focalLength; }
+  constexpr Standard_Real Focal() const noexcept { return focalLength; }
 
   //! -   Computes the focus of the parabola.
   gp_Pnt Focus() const;
 
   //! Returns the vertex of the parabola. It is the "Location"
   //! point of the coordinate system of the parabola.
-  const gp_Pnt& Location() const { return pos.Location(); }
+  constexpr const gp_Pnt& Location() const noexcept { return pos.Location(); }
 
   //! Computes the parameter of the parabola.
   //! It is the distance between the focus and the directrix of
   //! the parabola. This distance is twice the focal length.
-  Standard_Real Parameter() const { return 2.0 * focalLength; }
+  constexpr Standard_Real Parameter() const noexcept { return 2.0 * focalLength; }
 
   //! Returns the local coordinate system of the parabola.
-  const gp_Ax2& Position() const { return pos; }
+  constexpr const gp_Ax2& Position() const noexcept { return pos; }
 
   //! Returns the symmetry axis of the parabola. The location point
   //! of the axis is the vertex of the parabola.
-  gp_Ax1 XAxis() const { return gp_Ax1(pos.Location(), pos.XDirection()); }
+  constexpr gp_Ax1 XAxis() const noexcept { return gp_Ax1(pos.Location(), pos.XDirection()); }
 
   //! It is an axis parallel to the directrix of the parabola.
   //! The location point of this axis is the vertex of the parabola.
-  gp_Ax1 YAxis() const { return gp_Ax1(pos.Location(), pos.YDirection()); }
+  constexpr gp_Ax1 YAxis() const noexcept { return gp_Ax1(pos.Location(), pos.YDirection()); }
 
-  Standard_EXPORT void Mirror(const gp_Pnt& theP);
+  Standard_EXPORT void Mirror(const gp_Pnt& theP) noexcept;
 
   //! Performs the symmetrical transformation of a parabola
   //! with respect to the point theP which is the center of the
   //! symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Parab Mirrored(const gp_Pnt& theP) const;
+  Standard_NODISCARD Standard_EXPORT gp_Parab Mirrored(const gp_Pnt& theP) const noexcept;
 
   Standard_EXPORT void Mirror(const gp_Ax1& theA1);
 
@@ -194,21 +194,21 @@ public:
   //! Transforms a parabola with the transformation theT from class Trsf.
   Standard_NODISCARD gp_Parab Transformed(const gp_Trsf& theT) const;
 
-  void Translate(const gp_Vec& theV) { pos.Translate(theV); }
+  constexpr void Translate(const gp_Vec& theV) noexcept { pos.Translate(theV); }
 
   //! Translates a parabola in the direction of the vector theV.
   //! The magnitude of the translation is the vector's magnitude.
-  Standard_NODISCARD gp_Parab Translated(const gp_Vec& theV) const
+  Standard_NODISCARD gp_Parab Translated(const gp_Vec& theV) const noexcept
   {
     gp_Parab aPrb = *this;
     aPrb.pos.Translate(theV);
     return aPrb;
   }
 
-  void Translate(const gp_Pnt& theP1, const gp_Pnt& theP2) { pos.Translate(theP1, theP2); }
+  constexpr void Translate(const gp_Pnt& theP1, const gp_Pnt& theP2) noexcept { pos.Translate(theP1, theP2); }
 
   //! Translates a parabola from the point theP1 to the point theP2.
-  Standard_NODISCARD gp_Parab Translated(const gp_Pnt& theP1, const gp_Pnt& theP2) const
+  Standard_NODISCARD gp_Parab Translated(const gp_Pnt& theP1, const gp_Pnt& theP2) const noexcept
   {
     gp_Parab aPrb = *this;
     aPrb.pos.Translate(theP1, theP2);

--- a/src/FoundationClasses/TKMath/gp/gp_Parab.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Parab.hxx
@@ -205,7 +205,10 @@ public:
     return aPrb;
   }
 
-  constexpr void Translate(const gp_Pnt& theP1, const gp_Pnt& theP2) noexcept { pos.Translate(theP1, theP2); }
+  constexpr void Translate(const gp_Pnt& theP1, const gp_Pnt& theP2) noexcept
+  {
+    pos.Translate(theP1, theP2);
+  }
 
   //! Translates a parabola from the point theP1 to the point theP2.
   Standard_NODISCARD gp_Parab Translated(const gp_Pnt& theP1, const gp_Pnt& theP2) const noexcept

--- a/src/FoundationClasses/TKMath/gp/gp_Pln.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Pln.cxx
@@ -110,36 +110,36 @@ gp_Pln::gp_Pln(const Standard_Real A,
   }
 }
 
-void gp_Pln::Mirror(const gp_Pnt& P)
+void gp_Pln::Mirror(const gp_Pnt& P) noexcept
 {
   pos.Mirror(P);
 }
 
-gp_Pln gp_Pln::Mirrored(const gp_Pnt& P) const
+gp_Pln gp_Pln::Mirrored(const gp_Pnt& P) const noexcept
 {
   gp_Pln Pl = *this;
   Pl.pos.Mirror(P);
   return Pl;
 }
 
-void gp_Pln::Mirror(const gp_Ax1& A1)
+void gp_Pln::Mirror(const gp_Ax1& A1) noexcept
 {
   pos.Mirror(A1);
 }
 
-gp_Pln gp_Pln::Mirrored(const gp_Ax1& A1) const
+gp_Pln gp_Pln::Mirrored(const gp_Ax1& A1) const noexcept
 {
   gp_Pln Pl = *this;
   Pl.pos.Mirror(A1);
   return Pl;
 }
 
-void gp_Pln::Mirror(const gp_Ax2& A2)
+void gp_Pln::Mirror(const gp_Ax2& A2) noexcept
 {
   pos.Mirror(A2);
 }
 
-gp_Pln gp_Pln::Mirrored(const gp_Ax2& A2) const
+gp_Pln gp_Pln::Mirrored(const gp_Ax2& A2) const noexcept
 {
   gp_Pln Pl = *this;
   Pl.pos.Mirror(A2);

--- a/src/FoundationClasses/TKMath/gp/gp_Pln.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Pln.hxx
@@ -100,14 +100,14 @@ public:
 
   //! Reverses the U parametrization of the plane
   //! reversing the XAxis.
-  void UReverse() { pos.XReverse(); }
+  constexpr void UReverse() noexcept { pos.XReverse(); }
 
   //! Reverses the V parametrization of the plane
   //! reversing the YAxis.
-  void VReverse() { pos.YReverse(); }
+  constexpr void VReverse() noexcept { pos.YReverse(); }
 
   //! Returns true if the Ax3 is right handed.
-  constexpr Standard_Boolean Direct() const noexcept { return pos.Direct(); }
+  Standard_Boolean Direct() const { return pos.Direct(); }
 
   //! Returns the plane's normal Axis.
   constexpr const gp_Ax1& Axis() const noexcept { return pos.Axis(); }

--- a/src/FoundationClasses/TKMath/gp/gp_Pln.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Pln.hxx
@@ -162,7 +162,8 @@ public:
   //! AngularTolerance, and the distance between the origin
   //! of line L and this plane is less than or equal to
   //! theLinearTolerance.
-  Standard_Boolean Contains(const gp_Pnt& theP, const Standard_Real theLinearTolerance) const noexcept
+  Standard_Boolean Contains(const gp_Pnt&       theP,
+                            const Standard_Real theLinearTolerance) const noexcept
   {
     return Distance(theP) <= theLinearTolerance;
   }

--- a/src/FoundationClasses/TKMath/gp/gp_Pln.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Pln.hxx
@@ -84,7 +84,7 @@ public:
   void Coefficients(Standard_Real& theA,
                     Standard_Real& theB,
                     Standard_Real& theC,
-                    Standard_Real& theD) const;
+                    Standard_Real& theD) const noexcept;
 
   //! Modifies this plane, by redefining its local coordinate system so that
   //! -   its origin and "main Direction" become those of the
@@ -93,10 +93,10 @@ public:
   void SetAxis(const gp_Ax1& theA1) { pos.SetAxis(theA1); }
 
   //! Changes the origin of the plane.
-  void SetLocation(const gp_Pnt& theLoc) { pos.SetLocation(theLoc); }
+  constexpr void SetLocation(const gp_Pnt& theLoc) noexcept { pos.SetLocation(theLoc); }
 
   //! Changes the local coordinate system of the plane.
-  void SetPosition(const gp_Ax3& theA3) { pos = theA3; }
+  constexpr void SetPosition(const gp_Ax3& theA3) noexcept { pos = theA3; }
 
   //! Reverses the U parametrization of the plane
   //! reversing the XAxis.
@@ -107,52 +107,52 @@ public:
   void VReverse() { pos.YReverse(); }
 
   //! Returns true if the Ax3 is right handed.
-  Standard_Boolean Direct() const { return pos.Direct(); }
+  constexpr Standard_Boolean Direct() const noexcept { return pos.Direct(); }
 
   //! Returns the plane's normal Axis.
-  const gp_Ax1& Axis() const { return pos.Axis(); }
+  constexpr const gp_Ax1& Axis() const noexcept { return pos.Axis(); }
 
   //! Returns the plane's location (origin).
-  const gp_Pnt& Location() const { return pos.Location(); }
+  constexpr const gp_Pnt& Location() const noexcept { return pos.Location(); }
 
   //! Returns the local coordinate system of the plane.
-  const gp_Ax3& Position() const { return pos; }
+  constexpr const gp_Ax3& Position() const noexcept { return pos; }
 
   //! Computes the distance between <me> and the point <theP>.
-  Standard_Real Distance(const gp_Pnt& theP) const;
+  Standard_Real Distance(const gp_Pnt& theP) const noexcept;
 
   //! Computes the distance between <me> and the line <theL>.
-  Standard_Real Distance(const gp_Lin& theL) const;
+  Standard_Real Distance(const gp_Lin& theL) const noexcept;
 
   //! Computes the distance between two planes.
-  Standard_Real Distance(const gp_Pln& theOther) const;
+  Standard_Real Distance(const gp_Pln& theOther) const noexcept;
 
   //! Computes the square distance between <me> and the point <theP>.
-  Standard_Real SquareDistance(const gp_Pnt& theP) const
+  Standard_Real SquareDistance(const gp_Pnt& theP) const noexcept
   {
     Standard_Real aD = Distance(theP);
     return aD * aD;
   }
 
   //! Computes the square distance between <me> and the line <theL>.
-  Standard_Real SquareDistance(const gp_Lin& theL) const
+  Standard_Real SquareDistance(const gp_Lin& theL) const noexcept
   {
     Standard_Real aD = Distance(theL);
     return aD * aD;
   }
 
   //! Computes the square distance between two planes.
-  Standard_Real SquareDistance(const gp_Pln& theOther) const
+  Standard_Real SquareDistance(const gp_Pln& theOther) const noexcept
   {
     Standard_Real aD = Distance(theOther);
     return aD * aD;
   }
 
   //! Returns the X axis of the plane.
-  gp_Ax1 XAxis() const { return gp_Ax1(pos.Location(), pos.XDirection()); }
+  constexpr gp_Ax1 XAxis() const noexcept { return gp_Ax1(pos.Location(), pos.XDirection()); }
 
   //! Returns the Y axis of the plane.
-  gp_Ax1 YAxis() const { return gp_Ax1(pos.Location(), pos.YDirection()); }
+  constexpr gp_Ax1 YAxis() const noexcept { return gp_Ax1(pos.Location(), pos.YDirection()); }
 
   //! Returns true if this plane contains the point theP. This means that
   //! -   the distance between point theP and this plane is less
@@ -162,7 +162,7 @@ public:
   //! AngularTolerance, and the distance between the origin
   //! of line L and this plane is less than or equal to
   //! theLinearTolerance.
-  Standard_Boolean Contains(const gp_Pnt& theP, const Standard_Real theLinearTolerance) const
+  Standard_Boolean Contains(const gp_Pnt& theP, const Standard_Real theLinearTolerance) const noexcept
   {
     return Distance(theP) <= theLinearTolerance;
   }
@@ -177,22 +177,22 @@ public:
   //! theLinearTolerance.
   Standard_Boolean Contains(const gp_Lin&       theL,
                             const Standard_Real theLinearTolerance,
-                            const Standard_Real theAngularTolerance) const
+                            const Standard_Real theAngularTolerance) const noexcept
   {
     return Contains(theL.Location(), theLinearTolerance)
            && pos.Direction().IsNormal(theL.Direction(), theAngularTolerance);
   }
 
-  Standard_EXPORT void Mirror(const gp_Pnt& theP);
+  Standard_EXPORT void Mirror(const gp_Pnt& theP) noexcept;
 
   //! Performs the symmetrical transformation of a plane with respect
   //! to the point <theP> which is the center of the symmetry
   //! Warnings :
   //! The normal direction to the plane is not changed.
   //! The "XAxis" and the "YAxis" are reversed.
-  Standard_NODISCARD Standard_EXPORT gp_Pln Mirrored(const gp_Pnt& theP) const;
+  Standard_NODISCARD Standard_EXPORT gp_Pln Mirrored(const gp_Pnt& theP) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax1& theA1);
+  Standard_EXPORT void Mirror(const gp_Ax1& theA1) noexcept;
 
   //! Performs the symmetrical transformation of a plane with
   //! respect to an axis placement which is the axis of the
@@ -201,9 +201,9 @@ public:
   //! direction is the cross product between the "XDirection" and
   //! the "YDirection" after transformation if the initial plane
   //! was right handed, else it is the opposite.
-  Standard_NODISCARD Standard_EXPORT gp_Pln Mirrored(const gp_Ax1& theA1) const;
+  Standard_NODISCARD Standard_EXPORT gp_Pln Mirrored(const gp_Ax1& theA1) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax2& theA2);
+  Standard_EXPORT void Mirror(const gp_Ax2& theA2) noexcept;
 
   //! Performs the symmetrical transformation of a plane with
   //! respect to an axis placement. The axis placement <A2>
@@ -213,7 +213,7 @@ public:
   //! between the "XDirection" and the "YDirection" after
   //! transformation if the initial plane was right handed,
   //! else it is the opposite.
-  Standard_NODISCARD Standard_EXPORT gp_Pln Mirrored(const gp_Ax2& theA2) const;
+  Standard_NODISCARD Standard_EXPORT gp_Pln Mirrored(const gp_Ax2& theA2) const noexcept;
 
   void Rotate(const gp_Ax1& theA1, const Standard_Real theAng) { pos.Rotate(theA1, theAng); }
 
@@ -250,11 +250,11 @@ public:
     return aPl;
   }
 
-  void Translate(const gp_Vec& theV) { pos.Translate(theV); }
+  constexpr void Translate(const gp_Vec& theV) noexcept { pos.Translate(theV); }
 
   //! Translates a plane in the direction of the vector theV.
   //! The magnitude of the translation is the vector's magnitude.
-  Standard_NODISCARD gp_Pln Translated(const gp_Vec& theV) const
+  Standard_NODISCARD gp_Pln Translated(const gp_Vec& theV) const noexcept
   {
     gp_Pln aPl = *this;
     aPl.pos.Translate(theV);
@@ -283,7 +283,7 @@ private:
 inline void gp_Pln::Coefficients(Standard_Real& theA,
                                  Standard_Real& theB,
                                  Standard_Real& theC,
-                                 Standard_Real& theD) const
+                                 Standard_Real& theD) const noexcept
 {
   const gp_Dir& aDir = pos.Direction();
   if (pos.Direct())
@@ -304,7 +304,7 @@ inline void gp_Pln::Coefficients(Standard_Real& theA,
 
 //=================================================================================================
 
-inline Standard_Real gp_Pln::Distance(const gp_Pnt& theP) const
+inline Standard_Real gp_Pln::Distance(const gp_Pnt& theP) const noexcept
 {
   const gp_Pnt& aLoc = pos.Location();
   const gp_Dir& aDir = pos.Direction();
@@ -319,7 +319,7 @@ inline Standard_Real gp_Pln::Distance(const gp_Pnt& theP) const
 
 //=================================================================================================
 
-inline Standard_Real gp_Pln::Distance(const gp_Lin& theL) const
+inline Standard_Real gp_Pln::Distance(const gp_Lin& theL) const noexcept
 {
   Standard_Real aD = 0.0;
   if ((pos.Direction()).IsNormal(theL.Direction(), gp::Resolution()))
@@ -339,7 +339,7 @@ inline Standard_Real gp_Pln::Distance(const gp_Lin& theL) const
 
 //=================================================================================================
 
-inline Standard_Real gp_Pln::Distance(const gp_Pln& theOther) const
+inline Standard_Real gp_Pln::Distance(const gp_Pln& theOther) const noexcept
 {
   Standard_Real aD = 0.0;
   if ((pos.Direction()).IsParallel(theOther.pos.Direction(), gp::Resolution()))

--- a/src/FoundationClasses/TKMath/gp/gp_Pnt.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Pnt.cxx
@@ -52,7 +52,7 @@ void gp_Pnt::Transform(const gp_Trsf& T)
   }
 }
 
-void gp_Pnt::Mirror(const gp_Pnt& P)
+void gp_Pnt::Mirror(const gp_Pnt& P) noexcept
 {
   coord.Reverse();
   gp_XYZ XYZ = P.coord;
@@ -60,35 +60,35 @@ void gp_Pnt::Mirror(const gp_Pnt& P)
   coord.Add(XYZ);
 }
 
-gp_Pnt gp_Pnt::Mirrored(const gp_Pnt& P) const
+gp_Pnt gp_Pnt::Mirrored(const gp_Pnt& P) const noexcept
 {
   gp_Pnt Pres = *this;
   Pres.Mirror(P);
   return Pres;
 }
 
-void gp_Pnt::Mirror(const gp_Ax1& A1)
+void gp_Pnt::Mirror(const gp_Ax1& A1) noexcept
 {
   gp_Trsf T;
   T.SetMirror(A1);
   T.Transforms(coord);
 }
 
-gp_Pnt gp_Pnt::Mirrored(const gp_Ax1& A1) const
+gp_Pnt gp_Pnt::Mirrored(const gp_Ax1& A1) const noexcept
 {
   gp_Pnt P = *this;
   P.Mirror(A1);
   return P;
 }
 
-void gp_Pnt::Mirror(const gp_Ax2& A2)
+void gp_Pnt::Mirror(const gp_Ax2& A2) noexcept
 {
   gp_Trsf T;
   T.SetMirror(A2);
   T.Transforms(coord);
 }
 
-gp_Pnt gp_Pnt::Mirrored(const gp_Ax2& A2) const
+gp_Pnt gp_Pnt::Mirrored(const gp_Ax2& A2) const noexcept
 {
   gp_Pnt P = *this;
   P.Mirror(A2);

--- a/src/FoundationClasses/TKMath/gp/gp_Pnt.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Pnt.hxx
@@ -145,25 +145,25 @@ public:
   //! Performs the symmetrical transformation of a point
   //! with respect to the point theP which is the center of
   //! the  symmetry.
-  Standard_EXPORT void Mirror(const gp_Pnt& theP);
+  Standard_EXPORT void Mirror(const gp_Pnt& theP) noexcept;
 
   //! Performs the symmetrical transformation of a point
   //! with respect to an axis placement which is the axis
   //! of the symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Pnt Mirrored(const gp_Pnt& theP) const;
+  Standard_NODISCARD Standard_EXPORT gp_Pnt Mirrored(const gp_Pnt& theP) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax1& theA1);
+  Standard_EXPORT void Mirror(const gp_Ax1& theA1) noexcept;
 
   //! Performs the symmetrical transformation of a point
   //! with respect to a plane. The axis placement theA2 locates
   //! the plane of the symmetry : (Location, XDirection, YDirection).
-  Standard_NODISCARD Standard_EXPORT gp_Pnt Mirrored(const gp_Ax1& theA1) const;
+  Standard_NODISCARD Standard_EXPORT gp_Pnt Mirrored(const gp_Ax1& theA1) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax2& theA2);
+  Standard_EXPORT void Mirror(const gp_Ax2& theA2) noexcept;
 
   //! Rotates a point. theA1 is the axis of the rotation.
   //! theAng is the angular value of the rotation in radians.
-  Standard_NODISCARD Standard_EXPORT gp_Pnt Mirrored(const gp_Ax2& theA2) const;
+  Standard_NODISCARD Standard_EXPORT gp_Pnt Mirrored(const gp_Ax2& theA2) const noexcept;
 
   void Rotate(const gp_Ax1& theA1, const Standard_Real theAng);
 

--- a/src/FoundationClasses/TKMath/gp/gp_Sphere.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Sphere.cxx
@@ -59,36 +59,36 @@ void gp_Sphere::Coefficients(Standard_Real& A1,
   D                 = T14 * T14 + T24 * T24 + T34 * T34 - radius * radius;
 }
 
-void gp_Sphere::Mirror(const gp_Pnt& P)
+void gp_Sphere::Mirror(const gp_Pnt& P) noexcept
 {
   pos.Mirror(P);
 }
 
-gp_Sphere gp_Sphere::Mirrored(const gp_Pnt& P) const
+gp_Sphere gp_Sphere::Mirrored(const gp_Pnt& P) const noexcept
 {
   gp_Sphere C = *this;
   C.pos.Mirror(P);
   return C;
 }
 
-void gp_Sphere::Mirror(const gp_Ax1& A1)
+void gp_Sphere::Mirror(const gp_Ax1& A1) noexcept
 {
   pos.Mirror(A1);
 }
 
-gp_Sphere gp_Sphere::Mirrored(const gp_Ax1& A1) const
+gp_Sphere gp_Sphere::Mirrored(const gp_Ax1& A1) const noexcept
 {
   gp_Sphere C = *this;
   C.pos.Mirror(A1);
   return C;
 }
 
-void gp_Sphere::Mirror(const gp_Ax2& A2)
+void gp_Sphere::Mirror(const gp_Ax2& A2) noexcept
 {
   pos.Mirror(A2);
 }
 
-gp_Sphere gp_Sphere::Mirrored(const gp_Ax2& A2) const
+gp_Sphere gp_Sphere::Mirrored(const gp_Ax2& A2) const noexcept
 {
   gp_Sphere C = *this;
   C.pos.Mirror(A2);

--- a/src/FoundationClasses/TKMath/gp/gp_Sphere.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Sphere.hxx
@@ -63,10 +63,10 @@ public:
   }
 
   //! Changes the center of the sphere.
-  void SetLocation(const gp_Pnt& theLoc) { pos.SetLocation(theLoc); }
+  constexpr void SetLocation(const gp_Pnt& theLoc) noexcept { pos.SetLocation(theLoc); }
 
   //! Changes the local coordinate system of the sphere.
-  void SetPosition(const gp_Ax3& theA3) { pos = theA3; }
+  constexpr void SetPosition(const gp_Ax3& theA3) noexcept { pos = theA3; }
 
   //! Assigns theR the radius of the Sphere.
   //! Warnings :
@@ -80,7 +80,7 @@ public:
   }
 
   //! Computes the area of the sphere.
-  Standard_Real Area() const { return 4.0 * M_PI * radius * radius; }
+  constexpr Standard_Real Area() const noexcept { return 4.0 * M_PI * radius * radius; }
 
   //! Computes the coefficients of the implicit equation of the quadric
   //! in the absolute cartesian coordinates system :
@@ -109,47 +109,47 @@ public:
 
   //! Returns true if the local coordinate system of this sphere
   //! is right-handed.
-  Standard_Boolean Direct() const { return pos.Direct(); }
+  constexpr Standard_Boolean Direct() const noexcept { return pos.Direct(); }
 
   //! --- Purpose ;
   //! Returns the center of the sphere.
-  const gp_Pnt& Location() const { return pos.Location(); }
+  constexpr const gp_Pnt& Location() const noexcept { return pos.Location(); }
 
   //! Returns the local coordinates system of the sphere.
-  const gp_Ax3& Position() const { return pos; }
+  constexpr const gp_Ax3& Position() const noexcept { return pos; }
 
   //! Returns the radius of the sphere.
-  Standard_Real Radius() const { return radius; }
+  constexpr Standard_Real Radius() const noexcept { return radius; }
 
   //! Computes the volume of the sphere
-  Standard_Real Volume() const { return (4.0 * M_PI * radius * radius * radius) / 3.0; }
+  constexpr Standard_Real Volume() const noexcept { return (4.0 * M_PI * radius * radius * radius) / 3.0; }
 
   //! Returns the axis X of the sphere.
-  gp_Ax1 XAxis() const { return gp_Ax1(pos.Location(), pos.XDirection()); }
+  constexpr gp_Ax1 XAxis() const noexcept { return gp_Ax1(pos.Location(), pos.XDirection()); }
 
   //! Returns the axis Y of the sphere.
-  gp_Ax1 YAxis() const { return gp_Ax1(pos.Location(), pos.YDirection()); }
+  constexpr gp_Ax1 YAxis() const noexcept { return gp_Ax1(pos.Location(), pos.YDirection()); }
 
-  Standard_EXPORT void Mirror(const gp_Pnt& theP);
+  Standard_EXPORT void Mirror(const gp_Pnt& theP) noexcept;
 
   //! Performs the symmetrical transformation of a sphere
   //! with respect to the point theP which is the center of the
   //! symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Sphere Mirrored(const gp_Pnt& theP) const;
+  Standard_NODISCARD Standard_EXPORT gp_Sphere Mirrored(const gp_Pnt& theP) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax1& theA1);
+  Standard_EXPORT void Mirror(const gp_Ax1& theA1) noexcept;
 
   //! Performs the symmetrical transformation of a sphere with
   //! respect to an axis placement which is the axis of the
   //! symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Sphere Mirrored(const gp_Ax1& theA1) const;
+  Standard_NODISCARD Standard_EXPORT gp_Sphere Mirrored(const gp_Ax1& theA1) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax2& theA2);
+  Standard_EXPORT void Mirror(const gp_Ax2& theA2) noexcept;
 
   //! Performs the symmetrical transformation of a sphere with respect
   //! to a plane. The axis placement theA2 locates the plane of the
   //! of the symmetry : (Location, XDirection, YDirection).
-  Standard_NODISCARD Standard_EXPORT gp_Sphere Mirrored(const gp_Ax2& theA2) const;
+  Standard_NODISCARD Standard_EXPORT gp_Sphere Mirrored(const gp_Ax2& theA2) const noexcept;
 
   void Rotate(const gp_Ax1& theA1, const Standard_Real theAng) { pos.Rotate(theA1, theAng); }
 
@@ -173,11 +173,11 @@ public:
   //! Transforms a sphere with the transformation theT from class Trsf.
   Standard_NODISCARD gp_Sphere Transformed(const gp_Trsf& theT) const;
 
-  void Translate(const gp_Vec& theV) { pos.Translate(theV); }
+  constexpr void Translate(const gp_Vec& theV) noexcept { pos.Translate(theV); }
 
   //! Translates a sphere in the direction of the vector theV.
   //! The magnitude of the translation is the vector's magnitude.
-  Standard_NODISCARD gp_Sphere Translated(const gp_Vec& theV) const
+  Standard_NODISCARD gp_Sphere Translated(const gp_Vec& theV) const noexcept
   {
     gp_Sphere aC = *this;
     aC.pos.Translate(theV);

--- a/src/FoundationClasses/TKMath/gp/gp_Sphere.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Sphere.hxx
@@ -101,15 +101,15 @@ public:
 
   //! Reverses the   U   parametrization of   the sphere
   //! reversing the YAxis.
-  void UReverse() { pos.YReverse(); }
+  constexpr void UReverse() noexcept { pos.YReverse(); }
 
   //! Reverses the   V   parametrization of   the  sphere
   //! reversing the ZAxis.
-  void VReverse() { pos.ZReverse(); }
+  constexpr void VReverse() noexcept { pos.ZReverse(); }
 
   //! Returns true if the local coordinate system of this sphere
   //! is right-handed.
-  constexpr Standard_Boolean Direct() const noexcept { return pos.Direct(); }
+  Standard_Boolean Direct() const { return pos.Direct(); }
 
   //! --- Purpose ;
   //! Returns the center of the sphere.

--- a/src/FoundationClasses/TKMath/gp/gp_Sphere.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Sphere.hxx
@@ -122,7 +122,10 @@ public:
   constexpr Standard_Real Radius() const noexcept { return radius; }
 
   //! Computes the volume of the sphere
-  constexpr Standard_Real Volume() const noexcept { return (4.0 * M_PI * radius * radius * radius) / 3.0; }
+  constexpr Standard_Real Volume() const noexcept
+  {
+    return (4.0 * M_PI * radius * radius * radius) / 3.0;
+  }
 
   //! Returns the axis X of the sphere.
   constexpr gp_Ax1 XAxis() const noexcept { return gp_Ax1(pos.Location(), pos.XDirection()); }

--- a/src/FoundationClasses/TKMath/gp/gp_Torus.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Torus.cxx
@@ -151,36 +151,36 @@ void gp_Torus::Coefficients(TColStd_Array1OfReal& theCoef) const
                             + aSubRadius * aSubRadius;
 }
 
-void gp_Torus::Mirror(const gp_Pnt& P)
+void gp_Torus::Mirror(const gp_Pnt& P) noexcept
 {
   pos.Mirror(P);
 }
 
-gp_Torus gp_Torus::Mirrored(const gp_Pnt& P) const
+gp_Torus gp_Torus::Mirrored(const gp_Pnt& P) const noexcept
 {
   gp_Torus C = *this;
   C.pos.Mirror(P);
   return C;
 }
 
-void gp_Torus::Mirror(const gp_Ax1& A1)
+void gp_Torus::Mirror(const gp_Ax1& A1) noexcept
 {
   pos.Mirror(A1);
 }
 
-gp_Torus gp_Torus::Mirrored(const gp_Ax1& A1) const
+gp_Torus gp_Torus::Mirrored(const gp_Ax1& A1) const noexcept
 {
   gp_Torus C = *this;
   C.pos.Mirror(A1);
   return C;
 }
 
-void gp_Torus::Mirror(const gp_Ax2& A2)
+void gp_Torus::Mirror(const gp_Ax2& A2) noexcept
 {
   pos.Mirror(A2);
 }
 
-gp_Torus gp_Torus::Mirrored(const gp_Ax2& A2) const
+gp_Torus gp_Torus::Mirrored(const gp_Ax2& A2) const noexcept
 {
   gp_Torus C = *this;
   C.pos.Mirror(A2);

--- a/src/FoundationClasses/TKMath/gp/gp_Torus.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Torus.hxx
@@ -125,14 +125,14 @@ public:
 
   //! Reverses the   U   parametrization of   the  torus
   //! reversing the YAxis.
-  void UReverse() { pos.YReverse(); }
+  constexpr void UReverse() noexcept { pos.YReverse(); }
 
   //! Reverses the   V   parametrization of   the  torus
   //! reversing the ZAxis.
-  void VReverse() { pos.ZReverse(); }
+  constexpr void VReverse() noexcept { pos.ZReverse(); }
 
   //! returns true if the Ax3, the local coordinate system of this torus, is right handed.
-  constexpr Standard_Boolean Direct() const noexcept { return pos.Direct(); }
+  Standard_Boolean Direct() const { return pos.Direct(); }
 
   //! returns the symmetry axis of the torus.
   constexpr const gp_Ax1& Axis() const noexcept { return pos.Axis(); }

--- a/src/FoundationClasses/TKMath/gp/gp_Torus.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Torus.hxx
@@ -118,7 +118,10 @@ public:
   constexpr void SetPosition(const gp_Ax3& theA3) noexcept { pos = theA3; }
 
   //! Computes the area of the torus.
-  constexpr Standard_Real Area() const noexcept { return 4.0 * M_PI * M_PI * minorRadius * majorRadius; }
+  constexpr Standard_Real Area() const noexcept
+  {
+    return 4.0 * M_PI * M_PI * minorRadius * majorRadius;
+  }
 
   //! Reverses the   U   parametrization of   the  torus
   //! reversing the YAxis.

--- a/src/FoundationClasses/TKMath/gp/gp_Torus.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Torus.hxx
@@ -92,7 +92,7 @@ public:
   void SetAxis(const gp_Ax1& theA1) { pos.SetAxis(theA1); }
 
   //! Changes the location of the torus.
-  void SetLocation(const gp_Pnt& theLoc) { pos.SetLocation(theLoc); }
+  constexpr void SetLocation(const gp_Pnt& theLoc) noexcept { pos.SetLocation(theLoc); }
 
   //! Assigns value to the major radius  of this torus.
   //! Raises ConstructionError if theMajorRadius - MinorRadius <= Resolution()
@@ -115,10 +115,10 @@ public:
   }
 
   //! Changes the local coordinate system of the surface.
-  void SetPosition(const gp_Ax3& theA3) { pos = theA3; }
+  constexpr void SetPosition(const gp_Ax3& theA3) noexcept { pos = theA3; }
 
   //! Computes the area of the torus.
-  Standard_Real Area() const { return 4.0 * M_PI * M_PI * minorRadius * majorRadius; }
+  constexpr Standard_Real Area() const noexcept { return 4.0 * M_PI * M_PI * minorRadius * majorRadius; }
 
   //! Reverses the   U   parametrization of   the  torus
   //! reversing the YAxis.
@@ -129,10 +129,10 @@ public:
   void VReverse() { pos.ZReverse(); }
 
   //! returns true if the Ax3, the local coordinate system of this torus, is right handed.
-  Standard_Boolean Direct() const { return pos.Direct(); }
+  constexpr Standard_Boolean Direct() const noexcept { return pos.Direct(); }
 
   //! returns the symmetry axis of the torus.
-  const gp_Ax1& Axis() const { return pos.Axis(); }
+  constexpr const gp_Ax1& Axis() const noexcept { return pos.Axis(); }
 
   //! Computes the coefficients of the implicit equation of the surface
   //! in the absolute Cartesian coordinate system:
@@ -156,49 +156,49 @@ public:
   Standard_EXPORT void Coefficients(TColStd_Array1OfReal& theCoef) const;
 
   //! Returns the Torus's location.
-  const gp_Pnt& Location() const { return pos.Location(); }
+  constexpr const gp_Pnt& Location() const noexcept { return pos.Location(); }
 
   //! Returns the local coordinates system of the torus.
-  const gp_Ax3& Position() const { return pos; }
+  constexpr const gp_Ax3& Position() const noexcept { return pos; }
 
   //! returns the major radius of the torus.
-  Standard_Real MajorRadius() const { return majorRadius; }
+  constexpr Standard_Real MajorRadius() const noexcept { return majorRadius; }
 
   //! returns the minor radius of the torus.
-  Standard_Real MinorRadius() const { return minorRadius; }
+  constexpr Standard_Real MinorRadius() const noexcept { return minorRadius; }
 
   //! Computes the volume of the torus.
-  Standard_Real Volume() const
+  constexpr Standard_Real Volume() const noexcept
   {
     return (M_PI * minorRadius * minorRadius) * (2.0 * M_PI * majorRadius);
   }
 
   //! returns the axis X of the torus.
-  gp_Ax1 XAxis() const { return gp_Ax1(pos.Location(), pos.XDirection()); }
+  constexpr gp_Ax1 XAxis() const noexcept { return gp_Ax1(pos.Location(), pos.XDirection()); }
 
   //! returns the axis Y of the torus.
-  gp_Ax1 YAxis() const { return gp_Ax1(pos.Location(), pos.YDirection()); }
+  constexpr gp_Ax1 YAxis() const noexcept { return gp_Ax1(pos.Location(), pos.YDirection()); }
 
-  Standard_EXPORT void Mirror(const gp_Pnt& theP);
+  Standard_EXPORT void Mirror(const gp_Pnt& theP) noexcept;
 
   //! Performs the symmetrical transformation of a torus
   //! with respect to the point theP which is the center of the
   //! symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Torus Mirrored(const gp_Pnt& theP) const;
+  Standard_NODISCARD Standard_EXPORT gp_Torus Mirrored(const gp_Pnt& theP) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax1& theA1);
+  Standard_EXPORT void Mirror(const gp_Ax1& theA1) noexcept;
 
   //! Performs the symmetrical transformation of a torus with
   //! respect to an axis placement which is the axis of the
   //! symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Torus Mirrored(const gp_Ax1& theA1) const;
+  Standard_NODISCARD Standard_EXPORT gp_Torus Mirrored(const gp_Ax1& theA1) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax2& theA2);
+  Standard_EXPORT void Mirror(const gp_Ax2& theA2) noexcept;
 
   //! Performs the symmetrical transformation of a torus with respect
   //! to a plane. The axis placement theA2 locates the plane of the
   //! of the symmetry : (Location, XDirection, YDirection).
-  Standard_NODISCARD Standard_EXPORT gp_Torus Mirrored(const gp_Ax2& theA2) const;
+  Standard_NODISCARD Standard_EXPORT gp_Torus Mirrored(const gp_Ax2& theA2) const noexcept;
 
   void Rotate(const gp_Ax1& theA1, const Standard_Real theAng) { pos.Rotate(theA1, theAng); }
 
@@ -222,11 +222,11 @@ public:
   //! Transforms a torus with the transformation theT from class Trsf.
   Standard_NODISCARD gp_Torus Transformed(const gp_Trsf& theT) const;
 
-  void Translate(const gp_Vec& theV) { pos.Translate(theV); }
+  constexpr void Translate(const gp_Vec& theV) noexcept { pos.Translate(theV); }
 
   //! Translates a torus in the direction of the vector theV.
   //! The magnitude of the translation is the vector's magnitude.
-  Standard_NODISCARD gp_Torus Translated(const gp_Vec& theV) const
+  Standard_NODISCARD gp_Torus Translated(const gp_Vec& theV) const noexcept
   {
     gp_Torus aC = *this;
     aC.pos.Translate(theV);

--- a/src/FoundationClasses/TKMath/gp/gp_Trsf.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Trsf.cxx
@@ -56,7 +56,7 @@ gp_Trsf::gp_Trsf(const gp_Trsf2d& T)
 
 //=================================================================================================
 
-void gp_Trsf::SetMirror(const gp_Ax1& A1)
+void gp_Trsf::SetMirror(const gp_Ax1& A1) noexcept
 {
   shape = gp_Ax1Mirror;
   scale = 1;
@@ -72,7 +72,7 @@ void gp_Trsf::SetMirror(const gp_Ax1& A1)
 
 //=================================================================================================
 
-void gp_Trsf::SetMirror(const gp_Ax2& A2)
+void gp_Trsf::SetMirror(const gp_Ax2& A2) noexcept
 {
   shape = gp_Ax2Mirror;
   scale = -1;
@@ -243,7 +243,7 @@ void gp_Trsf::SetDisplacement(const gp_Ax3& FromA1, const gp_Ax3& ToA2)
 
 //=================================================================================================
 
-void gp_Trsf::SetTranslationPart(const gp_Vec& V)
+void gp_Trsf::SetTranslationPart(const gp_Vec& V) noexcept
 {
 
   loc                            = V.XYZ();

--- a/src/FoundationClasses/TKMath/gp/gp_Trsf.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Trsf.hxx
@@ -83,17 +83,17 @@ public:
 
   //! Makes the transformation into a symmetrical transformation.
   //! theP is the center of the symmetry.
-  void SetMirror(const gp_Pnt& theP);
+  void SetMirror(const gp_Pnt& theP) noexcept;
 
   //! Makes the transformation into a symmetrical transformation.
   //! theA1 is the center of the axial symmetry.
-  Standard_EXPORT void SetMirror(const gp_Ax1& theA1);
+  Standard_EXPORT void SetMirror(const gp_Ax1& theA1) noexcept;
 
   //! Makes the transformation into a symmetrical transformation.
   //! theA2 is the center of the planar symmetry
   //! and defines the plane of symmetry by its origin, "X
   //! Direction" and "Y Direction".
-  Standard_EXPORT void SetMirror(const gp_Ax2& theA2);
+  Standard_EXPORT void SetMirror(const gp_Ax2& theA2) noexcept;
 
   //! Changes the transformation into a rotation.
   //! theA1 is the rotation axis and theAng is the angular value of the
@@ -174,14 +174,14 @@ public:
 
   //! Changes the transformation into a translation.
   //! theV is the vector of the translation.
-  void SetTranslation(const gp_Vec& theV);
+  constexpr void SetTranslation(const gp_Vec& theV) noexcept;
 
   //! Makes the transformation into a translation where the translation vector
   //! is the vector (theP1, theP2) defined from point theP1 to point theP2.
-  void SetTranslation(const gp_Pnt& theP1, const gp_Pnt& theP2);
+  constexpr void SetTranslation(const gp_Pnt& theP1, const gp_Pnt& theP2) noexcept;
 
   //! Replaces the translation vector with the vector theV.
-  Standard_EXPORT void SetTranslationPart(const gp_Vec& theV);
+  Standard_EXPORT void SetTranslationPart(const gp_Vec& theV) noexcept;
 
   //! Modifies the scale factor.
   //! Raises ConstructionError  If theS is null.
@@ -387,7 +387,7 @@ inline constexpr gp_Trsf::gp_Trsf() noexcept
 
 //=================================================================================================
 
-inline void gp_Trsf::SetMirror(const gp_Pnt& theP)
+inline void gp_Trsf::SetMirror(const gp_Pnt& theP) noexcept
 {
   shape = gp_PntMirror;
   scale = -1.0;
@@ -398,7 +398,7 @@ inline void gp_Trsf::SetMirror(const gp_Pnt& theP)
 
 //=================================================================================================
 
-inline void gp_Trsf::SetTranslation(const gp_Vec& theV)
+inline constexpr void gp_Trsf::SetTranslation(const gp_Vec& theV) noexcept
 {
   shape = gp_Translation;
   scale = 1.;
@@ -408,7 +408,7 @@ inline void gp_Trsf::SetTranslation(const gp_Vec& theV)
 
 //=================================================================================================
 
-inline void gp_Trsf::SetTranslation(const gp_Pnt& theP1, const gp_Pnt& theP2)
+inline constexpr void gp_Trsf::SetTranslation(const gp_Pnt& theP1, const gp_Pnt& theP2) noexcept
 {
   shape = gp_Translation;
   scale = 1.0;

--- a/src/FoundationClasses/TKMath/gp/gp_Vec.cxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Vec.cxx
@@ -48,7 +48,7 @@ Standard_Boolean gp_Vec::IsEqual(const gp_Vec&       theOther,
   }
 }
 
-void gp_Vec::Mirror(const gp_Vec& theVec)
+void gp_Vec::Mirror(const gp_Vec& theVec) noexcept
 {
   const Standard_Real aMagnitude = theVec.coord.Modulus();
   if (aMagnitude > gp::Resolution())
@@ -77,7 +77,7 @@ void gp_Vec::Mirror(const gp_Vec& theVec)
   }
 }
 
-void gp_Vec::Mirror(const gp_Ax1& theAxis)
+void gp_Vec::Mirror(const gp_Ax1& theAxis) noexcept
 {
   const gp_XYZ&       aDirectionXYZ = theAxis.Direction().XYZ();
   const Standard_Real aOrigX        = coord.X();
@@ -100,7 +100,7 @@ void gp_Vec::Mirror(const gp_Ax1& theAxis)
   coord.SetZ(aCrossTermXZ * aOrigX + aCrossTermYZ * aOrigY + aZZTerm * aOrigZ);
 }
 
-void gp_Vec::Mirror(const gp_Ax2& theAxis)
+void gp_Vec::Mirror(const gp_Ax2& theAxis) noexcept
 {
   const gp_XYZ& aZDir   = theAxis.Direction().XYZ();
   const gp_XYZ  aMirXYZ = aZDir.Crossed(coord);
@@ -136,21 +136,21 @@ void gp_Vec::Transform(const gp_Trsf& theTransformation)
   }
 }
 
-gp_Vec gp_Vec::Mirrored(const gp_Vec& theVec) const
+gp_Vec gp_Vec::Mirrored(const gp_Vec& theVec) const noexcept
 {
   gp_Vec aResult = *this;
   aResult.Mirror(theVec);
   return aResult;
 }
 
-gp_Vec gp_Vec::Mirrored(const gp_Ax1& theAxis) const
+gp_Vec gp_Vec::Mirrored(const gp_Ax1& theAxis) const noexcept
 {
   gp_Vec aResult = *this;
   aResult.Mirror(theAxis);
   return aResult;
 }
 
-gp_Vec gp_Vec::Mirrored(const gp_Ax2& theAxis) const
+gp_Vec gp_Vec::Mirrored(const gp_Ax2& theAxis) const noexcept
 {
   gp_Vec aResult = *this;
   aResult.Mirror(theAxis);

--- a/src/FoundationClasses/TKMath/gp/gp_Vec.hxx
+++ b/src/FoundationClasses/TKMath/gp/gp_Vec.hxx
@@ -406,26 +406,26 @@ public:
     coord.SetLinearForm(theV1.coord, theV2.coord);
   }
 
-  Standard_EXPORT void Mirror(const gp_Vec& theV);
+  Standard_EXPORT void Mirror(const gp_Vec& theV) noexcept;
 
   //! Performs the symmetrical transformation of a vector
   //! with respect to the vector theV which is the center of
   //! the  symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Vec Mirrored(const gp_Vec& theV) const;
+  Standard_NODISCARD Standard_EXPORT gp_Vec Mirrored(const gp_Vec& theV) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax1& theA1);
+  Standard_EXPORT void Mirror(const gp_Ax1& theA1) noexcept;
 
   //! Performs the symmetrical transformation of a vector
   //! with respect to an axis placement which is the axis
   //! of the symmetry.
-  Standard_NODISCARD Standard_EXPORT gp_Vec Mirrored(const gp_Ax1& theA1) const;
+  Standard_NODISCARD Standard_EXPORT gp_Vec Mirrored(const gp_Ax1& theA1) const noexcept;
 
-  Standard_EXPORT void Mirror(const gp_Ax2& theA2);
+  Standard_EXPORT void Mirror(const gp_Ax2& theA2) noexcept;
 
   //! Performs the symmetrical transformation of a vector
   //! with respect to a plane. The axis placement theA2 locates
   //! the plane of the symmetry : (Location, XDirection, YDirection).
-  Standard_NODISCARD Standard_EXPORT gp_Vec Mirrored(const gp_Ax2& theA2) const;
+  Standard_NODISCARD Standard_EXPORT gp_Vec Mirrored(const gp_Ax2& theA2) const noexcept;
 
   void Rotate(const gp_Ax1& theA1, const Standard_Real theAng);
 


### PR DESCRIPTION
- Add noexcept to many small mutating and non-throwing methods (Mirror, Mirrored, SetMirror, SetTranslationPart, etc.) across gp classes.
- Annotate trivial getters, translators and small computations as constexpr where applicable (SetLocation/SetPosition, Area/Length/Radius/Volume, Axis/Location/Position accessors, Translate helpers).
- Update headers and source files to improve noexcept/constexpr conformance for gp geometry and math types, enabling better optimization and stronger exception-safety guarantees.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Enhanced exception-safety guarantees and compile-time optimization opportunities across mathematical geometry classes by marking transformation and accessor methods with stronger compiler directives. These internal improvements maintain existing functionality while enabling better performance and error handling guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->