### PR TITLE
Refactor error handling: Replace Storage exceptions with error state management

### DIFF
--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage.cxx
@@ -127,10 +127,9 @@ Storage_Error StdStorage::Read(const Handle(Storage_BaseDriver)& theDriver,
     {
       OCC_CATCH_SIGNALS
       theDriver->ReadReferenceType(aRef, aType);
-      anError = Storage_VSOk;
     }
-    
 
+    anError = theDriver->ErrorStatus();
     if (anError != Storage_VSOk)
       return anError;
 
@@ -151,12 +150,9 @@ Storage_Error StdStorage::Read(const Handle(Storage_BaseDriver)& theDriver,
     {
       OCC_CATCH_SIGNALS
       aReadData.ReadPersistentObject(i);
-      anError = Storage_VSOk;
     }
-    
-    
-    
 
+    anError = theDriver->ErrorStatus();
     if (anError != Storage_VSOk)
       return anError;
   }

--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage.cxx
@@ -29,9 +29,6 @@
 #include <StdStorage_BacketOfPersistent.hxx>
 #include <Storage.hxx>
 #include <Storage_BaseDriver.hxx>
-#include <Storage_StreamTypeMismatchError.hxx>
-#include <Storage_StreamFormatError.hxx>
-#include <Storage_StreamWriteError.hxx>
 
 #include <stdio.h>
 

--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage.cxx
@@ -57,6 +57,7 @@ Storage_Error StdStorage::Read(const TCollection_AsciiString& theFileName,
     return Storage_VSWrongFileDriver;
 
   // Try to open the file
+  try
   {
     OCC_CATCH_SIGNALS
     PCDM_ReadWriter::Open(aDriver, theFileName, Storage_VSRead);

--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage.cxx
@@ -300,7 +300,6 @@ Storage_Error StdStorage::Write(const Handle(Storage_BaseDriver)& theDriver,
     if (anError != Storage_VSOk)
       return anError;
   }
-  
 
   return Storage_VSOk;
 }

--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage.cxx
@@ -274,7 +274,13 @@ Storage_Error StdStorage::Write(const Handle(Storage_BaseDriver)& theDriver,
     {
       Handle(StdObjMgt_Persistent) aPObj = anIt.Value();
       if (!aPObj.IsNull())
+      {
         theDriver->WriteReferenceType(aPObj->RefNum(), aPObj->TypeNum());
+
+        anError = theDriver->ErrorStatus();
+        if (anError != Storage_VSOk)
+          return anError;
+      }
     }
 
     anError = theDriver->EndWriteRefSection();

--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage.cxx
@@ -125,7 +125,6 @@ Storage_Error StdStorage::Read(const Handle(Storage_BaseDriver)& theDriver,
   {
     Standard_Integer aRef = 0, aType = 0;
     {
-      OCC_CATCH_SIGNALS
       theDriver->ReadReferenceType(aRef, aType);
     }
 
@@ -148,7 +147,6 @@ Storage_Error StdStorage::Read(const Handle(Storage_BaseDriver)& theDriver,
   for (Standard_Integer i = 1; i <= aHeaderData->NumberOfObjects(); i++)
   {
     {
-      OCC_CATCH_SIGNALS
       aReadData.ReadPersistentObject(i);
     }
 

--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage.cxx
@@ -124,9 +124,7 @@ Storage_Error StdStorage::Read(const Handle(Storage_BaseDriver)& theDriver,
   for (Standard_Integer i = 1; i <= aNbRefs; i++)
   {
     Standard_Integer aRef = 0, aType = 0;
-    {
-      theDriver->ReadReferenceType(aRef, aType);
-    }
+    theDriver->ReadReferenceType(aRef, aType);
 
     anError = theDriver->ErrorStatus();
     if (anError != Storage_VSOk)

--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage.cxx
@@ -57,7 +57,6 @@ Storage_Error StdStorage::Read(const TCollection_AsciiString& theFileName,
     return Storage_VSWrongFileDriver;
 
   // Try to open the file
-  try
   {
     OCC_CATCH_SIGNALS
     PCDM_ReadWriter::Open(aDriver, theFileName, Storage_VSRead);
@@ -124,16 +123,12 @@ Storage_Error StdStorage::Read(const Handle(Storage_BaseDriver)& theDriver,
   for (Standard_Integer i = 1; i <= aNbRefs; i++)
   {
     Standard_Integer aRef = 0, aType = 0;
-    try
     {
       OCC_CATCH_SIGNALS
       theDriver->ReadReferenceType(aRef, aType);
       anError = Storage_VSOk;
     }
-    catch (Storage_StreamTypeMismatchError const&)
-    {
-      anError = Storage_VSTypeMismatch;
-    }
+    
 
     if (anError != Storage_VSOk)
       return anError;
@@ -152,24 +147,14 @@ Storage_Error StdStorage::Read(const Handle(Storage_BaseDriver)& theDriver,
 
   for (Standard_Integer i = 1; i <= aHeaderData->NumberOfObjects(); i++)
   {
-    try
     {
       OCC_CATCH_SIGNALS
       aReadData.ReadPersistentObject(i);
       anError = Storage_VSOk;
     }
-    catch (Storage_StreamTypeMismatchError const&)
-    {
-      anError = Storage_VSTypeMismatch;
-    }
-    catch (Storage_StreamFormatError const&)
-    {
-      anError = Storage_VSFormatError;
-    }
-    catch (Storage_StreamReadError const&)
-    {
-      anError = Storage_VSFormatError;
-    }
+    
+    
+    
 
     if (anError != Storage_VSOk)
       return anError;
@@ -269,7 +254,6 @@ Storage_Error StdStorage::Write(const Handle(Storage_BaseDriver)& theDriver,
   aHeaderData->SetStorageVersion(StdStorage::Version());
   aHeaderData->SetNumberOfObjects(aPObjs.Length());
 
-  try
   {
     // Write header section
     if (!aHeaderData->Write(theDriver))
@@ -319,10 +303,7 @@ Storage_Error StdStorage::Write(const Handle(Storage_BaseDriver)& theDriver,
     if (anError != Storage_VSOk)
       return anError;
   }
-  catch (Storage_StreamWriteError const&)
-  {
-    return Storage_VSWriteError;
-  }
+  
 
   return Storage_VSOk;
 }

--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage_HeaderData.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage_HeaderData.cxx
@@ -45,17 +45,15 @@ Standard_Boolean StdStorage_HeaderData::Read(const Handle(Storage_BaseDriver)& t
     return Standard_False;
   }
 
-  {
-    theDriver->ReadInfo(myNBObj,
-                        myStorageVersion,
-                        myDate,
-                        mySchemaName,
-                        mySchemaVersion,
-                        myApplicationName,
-                        myApplicationVersion,
-                        myDataType,
-                        myUserInfo);
-  }
+  theDriver->ReadInfo(myNBObj,
+                      myStorageVersion,
+                      myDate,
+                      mySchemaName,
+                      mySchemaVersion,
+                      myApplicationName,
+                      myApplicationVersion,
+                      myDataType,
+                      myUserInfo);
 
   if (theDriver->ErrorStatus() != Storage_VSOk)
   {
@@ -79,9 +77,7 @@ Standard_Boolean StdStorage_HeaderData::Read(const Handle(Storage_BaseDriver)& t
     return Standard_False;
   }
 
-  {
-    theDriver->ReadComment(myComments);
-  }
+  theDriver->ReadComment(myComments);
 
   if (theDriver->ErrorStatus() != Storage_VSOk)
   {
@@ -118,17 +114,15 @@ Standard_Boolean StdStorage_HeaderData::Write(const Handle(Storage_BaseDriver)& 
     return Standard_False;
   }
 
-  {
-    theDriver->WriteInfo(myNBObj,
-                         myStorageVersion,
-                         myDate,
-                         mySchemaName,
-                         mySchemaVersion,
-                         myApplicationName,
-                         myApplicationVersion,
-                         myDataType,
-                         myUserInfo);
-  }
+  theDriver->WriteInfo(myNBObj,
+                       myStorageVersion,
+                       myDate,
+                       mySchemaName,
+                       mySchemaVersion,
+                       myApplicationName,
+                       myApplicationVersion,
+                       myDataType,
+                       myUserInfo);
 
   if (theDriver->ErrorStatus() != Storage_VSOk)
   {
@@ -152,9 +146,7 @@ Standard_Boolean StdStorage_HeaderData::Write(const Handle(Storage_BaseDriver)& 
     return Standard_False;
   }
 
-  {
-    theDriver->WriteComment(myComments);
-  }
+  theDriver->WriteComment(myComments);
 
   if (theDriver->ErrorStatus() != Storage_VSOk)
   {

--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage_HeaderData.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage_HeaderData.cxx
@@ -45,7 +45,6 @@ Standard_Boolean StdStorage_HeaderData::Read(const Handle(Storage_BaseDriver)& t
     return Standard_False;
   }
 
-  try
   {
     OCC_CATCH_SIGNALS
     theDriver->ReadInfo(myNBObj,
@@ -58,18 +57,8 @@ Standard_Boolean StdStorage_HeaderData::Read(const Handle(Storage_BaseDriver)& t
                         myDataType,
                         myUserInfo);
   }
-  catch (Storage_StreamTypeMismatchError const&)
-  {
-    myErrorStatus    = Storage_VSTypeMismatch;
-    myErrorStatusExt = "ReadInfo";
-    return Standard_False;
-  }
-  catch (Storage_StreamExtCharParityError const&)
-  {
-    myErrorStatus    = Storage_VSExtCharParityError;
-    myErrorStatusExt = "ReadInfo";
-    return Standard_False;
-  }
+  
+  
 
   myErrorStatus = theDriver->EndReadInfoSection();
   if (myErrorStatus != Storage_VSOk)
@@ -86,23 +75,12 @@ Standard_Boolean StdStorage_HeaderData::Read(const Handle(Storage_BaseDriver)& t
     return Standard_False;
   }
 
-  try
   {
     OCC_CATCH_SIGNALS
     theDriver->ReadComment(myComments);
   }
-  catch (Storage_StreamTypeMismatchError const&)
-  {
-    myErrorStatus    = Storage_VSTypeMismatch;
-    myErrorStatusExt = "ReadComment";
-    return Standard_False;
-  }
-  catch (Storage_StreamExtCharParityError const&)
-  {
-    myErrorStatus    = Storage_VSExtCharParityError;
-    myErrorStatusExt = "ReadComment";
-    return Standard_False;
-  }
+  
+  
 
   myErrorStatus = theDriver->EndReadCommentSection();
   if (myErrorStatus != Storage_VSOk)
@@ -132,7 +110,6 @@ Standard_Boolean StdStorage_HeaderData::Write(const Handle(Storage_BaseDriver)& 
     return Standard_False;
   }
 
-  try
   {
     OCC_CATCH_SIGNALS
     theDriver->WriteInfo(myNBObj,
@@ -145,18 +122,8 @@ Standard_Boolean StdStorage_HeaderData::Write(const Handle(Storage_BaseDriver)& 
                          myDataType,
                          myUserInfo);
   }
-  catch (Storage_StreamTypeMismatchError const&)
-  {
-    myErrorStatus    = Storage_VSTypeMismatch;
-    myErrorStatusExt = "WriteInfo";
-    return Standard_False;
-  }
-  catch (Storage_StreamExtCharParityError const&)
-  {
-    myErrorStatus    = Storage_VSExtCharParityError;
-    myErrorStatusExt = "WriteInfo";
-    return Standard_False;
-  }
+  
+  
 
   myErrorStatus = theDriver->EndWriteInfoSection();
   if (myErrorStatus != Storage_VSOk)
@@ -173,23 +140,12 @@ Standard_Boolean StdStorage_HeaderData::Write(const Handle(Storage_BaseDriver)& 
     return Standard_False;
   }
 
-  try
   {
     OCC_CATCH_SIGNALS
     theDriver->WriteComment(myComments);
   }
-  catch (Storage_StreamTypeMismatchError const&)
-  {
-    myErrorStatus    = Storage_VSTypeMismatch;
-    myErrorStatusExt = "WriteComment";
-    return Standard_False;
-  }
-  catch (Storage_StreamExtCharParityError const&)
-  {
-    myErrorStatus    = Storage_VSExtCharParityError;
-    myErrorStatusExt = "WriteComment";
-    return Standard_False;
-  }
+  
+  
 
   myErrorStatus = theDriver->EndWriteCommentSection();
   if (myErrorStatus != Storage_VSOk)

--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage_HeaderData.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage_HeaderData.cxx
@@ -11,11 +11,8 @@
 // Alternatively, this file may be used under the terms of Open CASCADE
 // commercial license or contractual agreement.
 
-#include <Standard_ErrorHandler.hxx>
 #include <StdStorage_HeaderData.hxx>
 #include <Storage_BaseDriver.hxx>
-#include <Storage_StreamTypeMismatchError.hxx>
-#include <Storage_StreamExtCharParityError.hxx>
 #include <TCollection_AsciiString.hxx>
 #include <TCollection_ExtendedString.hxx>
 

--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage_HeaderData.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage_HeaderData.cxx
@@ -46,7 +46,6 @@ Standard_Boolean StdStorage_HeaderData::Read(const Handle(Storage_BaseDriver)& t
   }
 
   {
-    OCC_CATCH_SIGNALS
     theDriver->ReadInfo(myNBObj,
                         myStorageVersion,
                         myDate,
@@ -81,7 +80,6 @@ Standard_Boolean StdStorage_HeaderData::Read(const Handle(Storage_BaseDriver)& t
   }
 
   {
-    OCC_CATCH_SIGNALS
     theDriver->ReadComment(myComments);
   }
 
@@ -121,7 +119,6 @@ Standard_Boolean StdStorage_HeaderData::Write(const Handle(Storage_BaseDriver)& 
   }
 
   {
-    OCC_CATCH_SIGNALS
     theDriver->WriteInfo(myNBObj,
                          myStorageVersion,
                          myDate,
@@ -156,7 +153,6 @@ Standard_Boolean StdStorage_HeaderData::Write(const Handle(Storage_BaseDriver)& 
   }
 
   {
-    OCC_CATCH_SIGNALS
     theDriver->WriteComment(myComments);
   }
 

--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage_HeaderData.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage_HeaderData.cxx
@@ -57,8 +57,13 @@ Standard_Boolean StdStorage_HeaderData::Read(const Handle(Storage_BaseDriver)& t
                         myDataType,
                         myUserInfo);
   }
-  
-  
+
+  if (theDriver->ErrorStatus() != Storage_VSOk)
+  {
+    myErrorStatus    = theDriver->ErrorStatus();
+    myErrorStatusExt = "ReadInfo";
+    return Standard_False;
+  }
 
   myErrorStatus = theDriver->EndReadInfoSection();
   if (myErrorStatus != Storage_VSOk)
@@ -79,8 +84,13 @@ Standard_Boolean StdStorage_HeaderData::Read(const Handle(Storage_BaseDriver)& t
     OCC_CATCH_SIGNALS
     theDriver->ReadComment(myComments);
   }
-  
-  
+
+  if (theDriver->ErrorStatus() != Storage_VSOk)
+  {
+    myErrorStatus    = theDriver->ErrorStatus();
+    myErrorStatusExt = "ReadComment";
+    return Standard_False;
+  }
 
   myErrorStatus = theDriver->EndReadCommentSection();
   if (myErrorStatus != Storage_VSOk)
@@ -122,8 +132,13 @@ Standard_Boolean StdStorage_HeaderData::Write(const Handle(Storage_BaseDriver)& 
                          myDataType,
                          myUserInfo);
   }
-  
-  
+
+  if (theDriver->ErrorStatus() != Storage_VSOk)
+  {
+    myErrorStatus    = theDriver->ErrorStatus();
+    myErrorStatusExt = "WriteInfo";
+    return Standard_False;
+  }
 
   myErrorStatus = theDriver->EndWriteInfoSection();
   if (myErrorStatus != Storage_VSOk)
@@ -144,8 +159,13 @@ Standard_Boolean StdStorage_HeaderData::Write(const Handle(Storage_BaseDriver)& 
     OCC_CATCH_SIGNALS
     theDriver->WriteComment(myComments);
   }
-  
-  
+
+  if (theDriver->ErrorStatus() != Storage_VSOk)
+  {
+    myErrorStatus    = theDriver->ErrorStatus();
+    myErrorStatusExt = "WriteComment";
+    return Standard_False;
+  }
 
   myErrorStatus = theDriver->EndWriteCommentSection();
   if (myErrorStatus != Storage_VSOk)

--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage_RootData.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage_RootData.cxx
@@ -50,7 +50,6 @@ Standard_Boolean StdStorage_RootData::Read(const Handle(Storage_BaseDriver)& the
   for (Standard_Integer i = 1; i <= len; i++)
   {
     {
-      OCC_CATCH_SIGNALS
       theDriver->ReadRoot(aRootName, aRef, aTypeName);
     }
 
@@ -98,7 +97,6 @@ Standard_Boolean StdStorage_RootData::Write(const Handle(Storage_BaseDriver)& th
   {
     const Handle(StdStorage_Root)& aRoot = anIt.Value();
     {
-      OCC_CATCH_SIGNALS
       theDriver->WriteRoot(aRoot->Name(), aRoot->Reference(), aRoot->Type());
     }
 

--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage_RootData.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage_RootData.cxx
@@ -50,17 +50,11 @@ Standard_Boolean StdStorage_RootData::Read(const Handle(Storage_BaseDriver)& the
   Standard_Integer len = theDriver->RootSectionSize();
   for (Standard_Integer i = 1; i <= len; i++)
   {
-    try
     {
       OCC_CATCH_SIGNALS
       theDriver->ReadRoot(aRootName, aRef, aTypeName);
     }
-    catch (Storage_StreamTypeMismatchError const&)
-    {
-      myErrorStatus    = Storage_VSTypeMismatch;
-      myErrorStatusExt = "ReadRoot";
-      return Standard_False;
-    }
+    
 
     Handle(StdStorage_Root) aRoot = new StdStorage_Root(aRootName, aRef, aTypeName);
     myObjects.Add(aRootName, aRoot);
@@ -98,17 +92,11 @@ Standard_Boolean StdStorage_RootData::Write(const Handle(Storage_BaseDriver)& th
   for (StdStorage_MapOfRoots::Iterator anIt(myObjects); anIt.More(); anIt.Next())
   {
     const Handle(StdStorage_Root)& aRoot = anIt.Value();
-    try
     {
       OCC_CATCH_SIGNALS
       theDriver->WriteRoot(aRoot->Name(), aRoot->Reference(), aRoot->Type());
     }
-    catch (Storage_StreamTypeMismatchError const&)
-    {
-      myErrorStatus    = Storage_VSTypeMismatch;
-      myErrorStatusExt = "ReadRoot";
-      return Standard_False;
-    }
+    
   }
 
   myErrorStatus = theDriver->EndWriteRootSection();

--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage_RootData.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage_RootData.cxx
@@ -49,9 +49,7 @@ Standard_Boolean StdStorage_RootData::Read(const Handle(Storage_BaseDriver)& the
   Standard_Integer len = theDriver->RootSectionSize();
   for (Standard_Integer i = 1; i <= len; i++)
   {
-    {
-      theDriver->ReadRoot(aRootName, aRef, aTypeName);
-    }
+    theDriver->ReadRoot(aRootName, aRef, aTypeName);
 
     if (theDriver->ErrorStatus() != Storage_VSOk)
     {
@@ -96,9 +94,7 @@ Standard_Boolean StdStorage_RootData::Write(const Handle(Storage_BaseDriver)& th
   for (StdStorage_MapOfRoots::Iterator anIt(myObjects); anIt.More(); anIt.Next())
   {
     const Handle(StdStorage_Root)& aRoot = anIt.Value();
-    {
-      theDriver->WriteRoot(aRoot->Name(), aRoot->Reference(), aRoot->Type());
-    }
+    theDriver->WriteRoot(aRoot->Name(), aRoot->Reference(), aRoot->Type());
 
     if (theDriver->ErrorStatus() != Storage_VSOk)
     {

--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage_RootData.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage_RootData.cxx
@@ -54,7 +54,13 @@ Standard_Boolean StdStorage_RootData::Read(const Handle(Storage_BaseDriver)& the
       OCC_CATCH_SIGNALS
       theDriver->ReadRoot(aRootName, aRef, aTypeName);
     }
-    
+
+    if (theDriver->ErrorStatus() != Storage_VSOk)
+    {
+      myErrorStatus    = theDriver->ErrorStatus();
+      myErrorStatusExt = "ReadRoot";
+      return Standard_False;
+    }
 
     Handle(StdStorage_Root) aRoot = new StdStorage_Root(aRootName, aRef, aTypeName);
     myObjects.Add(aRootName, aRoot);
@@ -96,7 +102,13 @@ Standard_Boolean StdStorage_RootData::Write(const Handle(Storage_BaseDriver)& th
       OCC_CATCH_SIGNALS
       theDriver->WriteRoot(aRoot->Name(), aRoot->Reference(), aRoot->Type());
     }
-    
+
+    if (theDriver->ErrorStatus() != Storage_VSOk)
+    {
+      myErrorStatus    = theDriver->ErrorStatus();
+      myErrorStatusExt = "WriteRoot";
+      return Standard_False;
+    }
   }
 
   myErrorStatus = theDriver->EndWriteRootSection();

--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage_RootData.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage_RootData.cxx
@@ -16,7 +16,6 @@
 #include <StdStorage_RootData.hxx>
 #include <StdStorage_Root.hxx>
 #include <Storage_BaseDriver.hxx>
-#include <Storage_StreamTypeMismatchError.hxx>
 #include <TCollection_AsciiString.hxx>
 
 IMPLEMENT_STANDARD_RTTIEXT(StdStorage_RootData, Standard_Transient)

--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage_RootData.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage_RootData.cxx
@@ -12,7 +12,6 @@
 // commercial license or contractual agreement.
 
 #include <StdObjMgt_Persistent.hxx>
-#include <Standard_ErrorHandler.hxx>
 #include <StdStorage_RootData.hxx>
 #include <StdStorage_Root.hxx>
 #include <Storage_BaseDriver.hxx>

--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage_TypeData.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage_TypeData.cxx
@@ -55,7 +55,6 @@ Standard_Boolean StdStorage_TypeData::Read(const Handle(Storage_BaseDriver)& the
       OCC_CATCH_SIGNALS
       theDriver->ReadTypeInformations(aTypeNum, aTypeName);
     }
-    
 
     myPt.Add(aTypeName, aTypeNum);
   }
@@ -96,7 +95,6 @@ Standard_Boolean StdStorage_TypeData::Write(const Handle(Storage_BaseDriver)& th
       OCC_CATCH_SIGNALS
       theDriver->WriteTypeInformations(i, Type(i));
     }
-    
   }
 
   myErrorStatus = theDriver->EndWriteTypeSection();

--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage_TypeData.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage_TypeData.cxx
@@ -11,7 +11,6 @@
 // Alternatively, this file may be used under the terms of Open CASCADE
 // commercial license or contractual agreement.
 
-#include <Standard_ErrorHandler.hxx>
 #include <StdDrivers.hxx>
 #include <StdStorage_TypeData.hxx>
 #include <Storage_BaseDriver.hxx>

--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage_TypeData.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage_TypeData.cxx
@@ -51,17 +51,11 @@ Standard_Boolean StdStorage_TypeData::Read(const Handle(Storage_BaseDriver)& the
   Standard_Integer len = theDriver->TypeSectionSize();
   for (Standard_Integer i = 1; i <= len; i++)
   {
-    try
     {
       OCC_CATCH_SIGNALS
       theDriver->ReadTypeInformations(aTypeNum, aTypeName);
     }
-    catch (Storage_StreamTypeMismatchError const&)
-    {
-      myErrorStatus    = Storage_VSTypeMismatch;
-      myErrorStatusExt = "ReadTypeInformations";
-      return Standard_False;
-    }
+    
 
     myPt.Add(aTypeName, aTypeNum);
   }
@@ -98,17 +92,11 @@ Standard_Boolean StdStorage_TypeData::Write(const Handle(Storage_BaseDriver)& th
   theDriver->SetTypeSectionSize(len);
   for (Standard_Integer i = 1; i <= len; i++)
   {
-    try
     {
       OCC_CATCH_SIGNALS
       theDriver->WriteTypeInformations(i, Type(i));
     }
-    catch (Storage_StreamTypeMismatchError const&)
-    {
-      myErrorStatus    = Storage_VSTypeMismatch;
-      myErrorStatusExt = "WriteTypeInformations";
-      return Standard_False;
-    }
+    
   }
 
   myErrorStatus = theDriver->EndWriteTypeSection();

--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage_TypeData.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage_TypeData.cxx
@@ -55,6 +55,13 @@ Standard_Boolean StdStorage_TypeData::Read(const Handle(Storage_BaseDriver)& the
       theDriver->ReadTypeInformations(aTypeNum, aTypeName);
     }
 
+    if (theDriver->ErrorStatus() != Storage_VSOk)
+    {
+      myErrorStatus    = theDriver->ErrorStatus();
+      myErrorStatusExt = "ReadTypeInformations";
+      return Standard_False;
+    }
+
     myPt.Add(aTypeName, aTypeNum);
   }
 
@@ -92,6 +99,13 @@ Standard_Boolean StdStorage_TypeData::Write(const Handle(Storage_BaseDriver)& th
   {
     {
       theDriver->WriteTypeInformations(i, Type(i));
+    }
+
+    if (theDriver->ErrorStatus() != Storage_VSOk)
+    {
+      myErrorStatus    = theDriver->ErrorStatus();
+      myErrorStatusExt = "WriteTypeInformations";
+      return Standard_False;
     }
   }
 

--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage_TypeData.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage_TypeData.cxx
@@ -15,7 +15,6 @@
 #include <StdDrivers.hxx>
 #include <StdStorage_TypeData.hxx>
 #include <Storage_BaseDriver.hxx>
-#include <Storage_StreamTypeMismatchError.hxx>
 #include <TCollection_AsciiString.hxx>
 
 IMPLEMENT_STANDARD_RTTIEXT(StdStorage_TypeData, Standard_Transient)
@@ -51,9 +50,7 @@ Standard_Boolean StdStorage_TypeData::Read(const Handle(Storage_BaseDriver)& the
   Standard_Integer len = theDriver->TypeSectionSize();
   for (Standard_Integer i = 1; i <= len; i++)
   {
-    {
-      theDriver->ReadTypeInformations(aTypeNum, aTypeName);
-    }
+    theDriver->ReadTypeInformations(aTypeNum, aTypeName);
 
     if (theDriver->ErrorStatus() != Storage_VSOk)
     {
@@ -97,9 +94,7 @@ Standard_Boolean StdStorage_TypeData::Write(const Handle(Storage_BaseDriver)& th
   theDriver->SetTypeSectionSize(len);
   for (Standard_Integer i = 1; i <= len; i++)
   {
-    {
-      theDriver->WriteTypeInformations(i, Type(i));
-    }
+    theDriver->WriteTypeInformations(i, Type(i));
 
     if (theDriver->ErrorStatus() != Storage_VSOk)
     {

--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage_TypeData.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage_TypeData.cxx
@@ -52,7 +52,6 @@ Standard_Boolean StdStorage_TypeData::Read(const Handle(Storage_BaseDriver)& the
   for (Standard_Integer i = 1; i <= len; i++)
   {
     {
-      OCC_CATCH_SIGNALS
       theDriver->ReadTypeInformations(aTypeNum, aTypeName);
     }
 
@@ -92,7 +91,6 @@ Standard_Boolean StdStorage_TypeData::Write(const Handle(Storage_BaseDriver)& th
   for (Standard_Integer i = 1; i <= len; i++)
   {
     {
-      OCC_CATCH_SIGNALS
       theDriver->WriteTypeInformations(i, Type(i));
     }
   }

--- a/src/ApplicationFramework/TKStdL/StdLDrivers/StdLDrivers_DocumentRetrievalDriver.cxx
+++ b/src/ApplicationFramework/TKStdL/StdLDrivers/StdLDrivers_DocumentRetrievalDriver.cxx
@@ -177,7 +177,6 @@ Handle(StdObjMgt_Persistent) StdLDrivers_DocumentRetrievalDriver::read(
   {
     Standard_Integer aRef = 0, aType = 0;
     {
-      OCC_CATCH_SIGNALS
       aFileDriver->ReadReferenceType(aRef, aType);
     }
 
@@ -194,7 +193,6 @@ Handle(StdObjMgt_Persistent) StdLDrivers_DocumentRetrievalDriver::read(
   for (i = 1; i <= theHeaderData.NumberOfObjects(); i++)
   {
     {
-      OCC_CATCH_SIGNALS
       aReadData.ReadPersistentObject(i);
     }
 

--- a/src/ApplicationFramework/TKStdL/StdLDrivers/StdLDrivers_DocumentRetrievalDriver.cxx
+++ b/src/ApplicationFramework/TKStdL/StdLDrivers/StdLDrivers_DocumentRetrievalDriver.cxx
@@ -78,6 +78,7 @@ Handle(StdObjMgt_Persistent) StdLDrivers_DocumentRetrievalDriver::read(
   }
 
   // Try to open the file
+  try
   {
     OCC_CATCH_SIGNALS
     PCDM_ReadWriter::Open(aFileDriver, theFileName, Storage_VSRead);

--- a/src/ApplicationFramework/TKStdL/StdLDrivers/StdLDrivers_DocumentRetrievalDriver.cxx
+++ b/src/ApplicationFramework/TKStdL/StdLDrivers/StdLDrivers_DocumentRetrievalDriver.cxx
@@ -78,7 +78,6 @@ Handle(StdObjMgt_Persistent) StdLDrivers_DocumentRetrievalDriver::read(
   }
 
   // Try to open the file
-  try
   {
     OCC_CATCH_SIGNALS
     PCDM_ReadWriter::Open(aFileDriver, theFileName, Storage_VSRead);
@@ -180,16 +179,12 @@ Handle(StdObjMgt_Persistent) StdLDrivers_DocumentRetrievalDriver::read(
   {
     Standard_Integer aRef = 0, aType = 0;
     Storage_Error    anError;
-    try
     {
       OCC_CATCH_SIGNALS
       aFileDriver->ReadReferenceType(aRef, aType);
       anError = Storage_VSOk;
     }
-    catch (Storage_StreamTypeMismatchError const&)
-    {
-      anError = Storage_VSTypeMismatch;
-    }
+    
 
     raiseOnStorageError(anError);
 
@@ -204,24 +199,14 @@ Handle(StdObjMgt_Persistent) StdLDrivers_DocumentRetrievalDriver::read(
   for (i = 1; i <= theHeaderData.NumberOfObjects(); i++)
   {
     Storage_Error anError;
-    try
     {
       OCC_CATCH_SIGNALS
       aReadData.ReadPersistentObject(i);
       anError = Storage_VSOk;
     }
-    catch (Storage_StreamTypeMismatchError const&)
-    {
-      anError = Storage_VSTypeMismatch;
-    }
-    catch (Storage_StreamFormatError const&)
-    {
-      anError = Storage_VSFormatError;
-    }
-    catch (Storage_StreamReadError const&)
-    {
-      anError = Storage_VSFormatError;
-    }
+    
+    
+    
 
     raiseOnStorageError(anError);
   }

--- a/src/ApplicationFramework/TKStdL/StdLDrivers/StdLDrivers_DocumentRetrievalDriver.cxx
+++ b/src/ApplicationFramework/TKStdL/StdLDrivers/StdLDrivers_DocumentRetrievalDriver.cxx
@@ -21,9 +21,6 @@
 #include <Storage_TypeData.hxx>
 #include <Storage_RootData.hxx>
 #include <Storage_BaseDriver.hxx>
-#include <Storage_StreamTypeMismatchError.hxx>
-#include <Storage_StreamFormatError.hxx>
-#include <Storage_StreamReadError.hxx>
 
 #include <PCDM.hxx>
 #include <PCDM_ReadWriter.hxx>

--- a/src/ApplicationFramework/TKStdL/StdLDrivers/StdLDrivers_DocumentRetrievalDriver.cxx
+++ b/src/ApplicationFramework/TKStdL/StdLDrivers/StdLDrivers_DocumentRetrievalDriver.cxx
@@ -179,15 +179,12 @@ Handle(StdObjMgt_Persistent) StdLDrivers_DocumentRetrievalDriver::read(
   for (i = 1; i <= len; i++)
   {
     Standard_Integer aRef = 0, aType = 0;
-    Storage_Error    anError;
     {
       OCC_CATCH_SIGNALS
       aFileDriver->ReadReferenceType(aRef, aType);
-      anError = Storage_VSOk;
     }
-    
 
-    raiseOnStorageError(anError);
+    raiseOnStorageError(aFileDriver->ErrorStatus());
 
     aReadData.CreatePersistentObject(aRef, anInstantiators(aType));
   }
@@ -199,17 +196,12 @@ Handle(StdObjMgt_Persistent) StdLDrivers_DocumentRetrievalDriver::read(
 
   for (i = 1; i <= theHeaderData.NumberOfObjects(); i++)
   {
-    Storage_Error anError;
     {
       OCC_CATCH_SIGNALS
       aReadData.ReadPersistentObject(i);
-      anError = Storage_VSOk;
     }
-    
-    
-    
 
-    raiseOnStorageError(anError);
+    raiseOnStorageError(aFileDriver->ErrorStatus());
   }
 
   raiseOnStorageError(aFileDriver->EndReadDataSection());

--- a/src/FoundationClasses/TKernel/FSD/FSD_BinaryFile.cxx
+++ b/src/FoundationClasses/TKernel/FSD/FSD_BinaryFile.cxx
@@ -1309,7 +1309,12 @@ void FSD_BinaryFile::ReadString(TCollection_AsciiString& aString)
     Standard_Character* c =
       (Standard_Character*)Standard::Allocate((size + 1) * sizeof(Standard_Character));
     if (!fread(c, size, 1, myStream))
+    {
       SetErrorStatus(Storage_VSTypeMismatch);
+      Standard::Free(c);
+      aString.Clear();
+      return;
+    }
     c[size] = '\0';
     aString = c;
     Standard::Free(c);
@@ -1451,7 +1456,12 @@ void FSD_BinaryFile::ReadExtendedString(TCollection_ExtendedString& aString)
     Standard_ExtCharacter* c =
       (Standard_ExtCharacter*)Standard::Allocate((size + 1) * sizeof(Standard_ExtCharacter));
     if (!fread(c, size * sizeof(Standard_ExtCharacter), 1, myStream))
+    {
       SetErrorStatus(Storage_VSTypeMismatch);
+      Standard::Free(c);
+      aString.Clear();
+      return;
+    }
     c[size] = '\0';
 #if OCCT_BINARY_FILE_DO_INVERSE
     for (Standard_Integer i = 0; i < size; i++)

--- a/src/FoundationClasses/TKernel/FSD/FSD_BinaryFile.cxx
+++ b/src/FoundationClasses/TKernel/FSD/FSD_BinaryFile.cxx
@@ -1309,7 +1309,7 @@ void FSD_BinaryFile::ReadString(TCollection_AsciiString& aString)
     Standard_Character* c =
       (Standard_Character*)Standard::Allocate((size + 1) * sizeof(Standard_Character));
     if (!fread(c, size, 1, myStream))
-      SetErrorStatus(Storage_VSWriteError);
+      SetErrorStatus(Storage_VSTypeMismatch);
     c[size] = '\0';
     aString = c;
     Standard::Free(c);
@@ -1451,7 +1451,7 @@ void FSD_BinaryFile::ReadExtendedString(TCollection_ExtendedString& aString)
     Standard_ExtCharacter* c =
       (Standard_ExtCharacter*)Standard::Allocate((size + 1) * sizeof(Standard_ExtCharacter));
     if (!fread(c, size * sizeof(Standard_ExtCharacter), 1, myStream))
-      SetErrorStatus(Storage_VSWriteError);
+      SetErrorStatus(Storage_VSTypeMismatch);
     c[size] = '\0';
 #if OCCT_BINARY_FILE_DO_INVERSE
     for (Standard_Integer i = 0; i < size; i++)

--- a/src/FoundationClasses/TKernel/FSD/FSD_BinaryFile.cxx
+++ b/src/FoundationClasses/TKernel/FSD/FSD_BinaryFile.cxx
@@ -260,10 +260,6 @@ Standard_Integer FSD_BinaryFile::PutInteger(Standard_OStream&      theOStream,
   if (!theOnlyCount)
   {
     theOStream.write((char*)&t, sizeof(Standard_Integer));
-    if (theOStream.fail())
-    {
-      SetErrorStatus(Storage_VSWriteError);
-    }
   }
 
   return sizeof(Standard_Integer);
@@ -338,13 +334,9 @@ void FSD_BinaryFile::GetReference(Standard_IStream& theIStream, Standard_Integer
 {
   theIStream.read((char*)&aValue, sizeof(Standard_Integer));
 
-  if (theIStream.gcount() != sizeof(Standard_Integer))
-  {
-    SetErrorStatus(Storage_VSTypeMismatch);
-  }
-
 #if OCCT_BINARY_FILE_DO_INVERSE
-  aValue = InverseInt(aValue);
+  if (theIStream.gcount() == sizeof(Standard_Integer))
+    aValue = InverseInt(aValue);
 #endif
 }
 
@@ -388,13 +380,9 @@ void FSD_BinaryFile::GetInteger(Standard_IStream& theIStream, Standard_Integer& 
 
   theIStream.read((char*)&theValue, sizeof(Standard_Integer));
 
-  if (theIStream.gcount() != sizeof(Standard_Integer))
-  {
-    SetErrorStatus(Storage_VSTypeMismatch);
-  }
-
 #if OCCT_BINARY_FILE_DO_INVERSE
-  theValue = InverseInt(theValue);
+  if (theIStream.gcount() == sizeof(Standard_Integer))
+    theValue = InverseInt(theValue);
 #endif
 }
 
@@ -1301,10 +1289,6 @@ Standard_Integer FSD_BinaryFile::WriteString(Standard_OStream&              theO
   if (anAsciiStrLen > 0 && !theOnlyCount)
   {
     theOStream.write(theString.ToCString(), theString.Length());
-    if (theOStream.fail())
-    {
-      SetErrorStatus(Storage_VSWriteError);
-    }
   }
 
   return aNumAndStrLen;
@@ -1353,14 +1337,18 @@ void FSD_BinaryFile::ReadString(Standard_IStream& theIStream, TCollection_AsciiS
 
     if (!theIStream.good())
     {
-      SetErrorStatus(Storage_VSFormatError); return;
+      aString.Clear();
+      Standard::Free(c);
+      return;
     }
 
     theIStream.read(c, size);
 
     if (theIStream.gcount() != size)
     {
-      SetErrorStatus(Storage_VSFormatError); return;
+      aString.Clear();
+      Standard::Free(c);
+      return;
     }
 
     c[size] = '\0';
@@ -1443,10 +1431,6 @@ Standard_Integer FSD_BinaryFile::WriteExtendedString(Standard_OStream&          
 #endif
 
     theOStream.write((char*)anExtStr, sizeof(Standard_ExtCharacter) * theString.Length());
-    if (theOStream.fail())
-    {
-      SetErrorStatus(Storage_VSWriteError);
-    }
   }
 
   return aNumAndStrLen;
@@ -1500,14 +1484,18 @@ void FSD_BinaryFile::ReadExtendedString(Standard_IStream&           theIStream,
 
     if (!theIStream.good())
     {
-      SetErrorStatus(Storage_VSFormatError); return;
+      aString.Clear();
+      Standard::Free(c);
+      return;
     }
 
     const std::streamsize aNbBytes = std::streamsize(sizeof(Standard_ExtCharacter) * size);
     theIStream.read((char*)c, aNbBytes);
     if (theIStream.gcount() != aNbBytes)
     {
-      SetErrorStatus(Storage_VSFormatError); return;
+      aString.Clear();
+      Standard::Free(c);
+      return;
     }
 
     c[size] = '\0';

--- a/src/FoundationClasses/TKernel/FSD/FSD_BinaryFile.cxx
+++ b/src/FoundationClasses/TKernel/FSD/FSD_BinaryFile.cxx
@@ -195,10 +195,10 @@ Storage_BaseDriver& FSD_BinaryFile::PutReference(const Standard_Integer aValue)
   Standard_Integer t = InverseInt(aValue);
 
   if (!fwrite(&t, sizeof(Standard_Integer), 1, myStream))
-    throw Storage_StreamWriteError();
+    SetErrorStatus(Storage_VSWriteError);
 #else
   if (!fwrite(&aValue, sizeof(Standard_Integer), 1, myStream))
-    throw Storage_StreamWriteError();
+    SetErrorStatus(Storage_VSWriteError);
 #endif
   return *this;
 }
@@ -208,7 +208,7 @@ Storage_BaseDriver& FSD_BinaryFile::PutReference(const Standard_Integer aValue)
 Storage_BaseDriver& FSD_BinaryFile::PutCharacter(const Standard_Character aValue)
 {
   if (!fwrite(&aValue, sizeof(Standard_Character), 1, myStream))
-    throw Storage_StreamWriteError();
+    SetErrorStatus(Storage_VSWriteError);
   return *this;
 }
 
@@ -220,10 +220,10 @@ Storage_BaseDriver& FSD_BinaryFile::PutExtCharacter(const Standard_ExtCharacter 
   Standard_ExtCharacter t = InverseExtChar(aValue);
 
   if (!fwrite(&t, sizeof(Standard_ExtCharacter), 1, myStream))
-    throw Storage_StreamWriteError();
+    SetErrorStatus(Storage_VSWriteError);
 #else
   if (!fwrite(&aValue, sizeof(Standard_ExtCharacter), 1, myStream))
-    throw Storage_StreamWriteError();
+    SetErrorStatus(Storage_VSWriteError);
 #endif
   return *this;
 }
@@ -236,10 +236,10 @@ Storage_BaseDriver& FSD_BinaryFile::PutInteger(const Standard_Integer aValue)
   Standard_Integer t = InverseInt(aValue);
 
   if (!fwrite(&t, sizeof(Standard_Integer), 1, myStream))
-    throw Storage_StreamWriteError();
+    SetErrorStatus(Storage_VSWriteError);
 #else
   if (!fwrite(&aValue, sizeof(Standard_Integer), 1, myStream))
-    throw Storage_StreamWriteError();
+    SetErrorStatus(Storage_VSWriteError);
 #endif
 
   return *this;
@@ -262,7 +262,7 @@ Standard_Integer FSD_BinaryFile::PutInteger(Standard_OStream&      theOStream,
     theOStream.write((char*)&t, sizeof(Standard_Integer));
     if (theOStream.fail())
     {
-      throw Storage_StreamWriteError();
+      SetErrorStatus(Storage_VSWriteError);
     }
   }
 
@@ -279,7 +279,7 @@ Storage_BaseDriver& FSD_BinaryFile::PutBoolean(const Standard_Boolean aValue)
   Standard_Integer t = aValue ? 1 : 0;
 #endif
   if (!fwrite(&t, sizeof(Standard_Integer), 1, myStream))
-    throw Storage_StreamWriteError();
+    SetErrorStatus(Storage_VSWriteError);
   return *this;
 }
 
@@ -291,10 +291,10 @@ Storage_BaseDriver& FSD_BinaryFile::PutReal(const Standard_Real aValue)
   Standard_Real t = InverseReal(aValue);
 
   if (!fwrite(&t, sizeof(Standard_Real), 1, myStream))
-    throw Storage_StreamWriteError();
+    SetErrorStatus(Storage_VSWriteError);
 #else
   if (!fwrite(&aValue, sizeof(Standard_Real), 1, myStream))
-    throw Storage_StreamWriteError();
+    SetErrorStatus(Storage_VSWriteError);
 #endif
   return *this;
 }
@@ -307,10 +307,10 @@ Storage_BaseDriver& FSD_BinaryFile::PutShortReal(const Standard_ShortReal aValue
   Standard_ShortReal t = InverseShortReal(aValue);
 
   if (!fwrite(&t, sizeof(Standard_ShortReal), 1, myStream))
-    throw Storage_StreamWriteError();
+    SetErrorStatus(Storage_VSWriteError);
 #else
   if (!fwrite(&aValue, sizeof(Standard_ShortReal), 1, myStream))
-    throw Storage_StreamWriteError();
+    SetErrorStatus(Storage_VSWriteError);
 #endif
   return *this;
 }
@@ -323,7 +323,7 @@ Storage_BaseDriver& FSD_BinaryFile::PutShortReal(const Standard_ShortReal aValue
 Storage_BaseDriver& FSD_BinaryFile::GetReference(Standard_Integer& aValue)
 {
   if (!fread(&aValue, sizeof(Standard_Integer), 1, myStream))
-    throw Storage_StreamTypeMismatchError();
+    SetErrorStatus(Storage_VSTypeMismatch);
 #if OCCT_BINARY_FILE_DO_INVERSE
   aValue = InverseInt(aValue);
 #endif
@@ -340,7 +340,7 @@ void FSD_BinaryFile::GetReference(Standard_IStream& theIStream, Standard_Integer
 
   if (theIStream.gcount() != sizeof(Standard_Integer))
   {
-    throw Storage_StreamTypeMismatchError();
+    SetErrorStatus(Storage_VSTypeMismatch);
   }
 
 #if OCCT_BINARY_FILE_DO_INVERSE
@@ -353,7 +353,7 @@ void FSD_BinaryFile::GetReference(Standard_IStream& theIStream, Standard_Integer
 Storage_BaseDriver& FSD_BinaryFile::GetCharacter(Standard_Character& aValue)
 {
   if (!fread(&aValue, sizeof(Standard_Character), 1, myStream))
-    throw Storage_StreamTypeMismatchError();
+    SetErrorStatus(Storage_VSTypeMismatch);
   return *this;
 }
 
@@ -362,7 +362,7 @@ Storage_BaseDriver& FSD_BinaryFile::GetCharacter(Standard_Character& aValue)
 Storage_BaseDriver& FSD_BinaryFile::GetExtCharacter(Standard_ExtCharacter& aValue)
 {
   if (!fread(&aValue, sizeof(Standard_ExtCharacter), 1, myStream))
-    throw Storage_StreamTypeMismatchError();
+    SetErrorStatus(Storage_VSTypeMismatch);
 #if OCCT_BINARY_FILE_DO_INVERSE
   aValue = InverseExtChar(aValue);
 #endif
@@ -374,7 +374,7 @@ Storage_BaseDriver& FSD_BinaryFile::GetExtCharacter(Standard_ExtCharacter& aValu
 Storage_BaseDriver& FSD_BinaryFile::GetInteger(Standard_Integer& aValue)
 {
   if (!fread(&aValue, sizeof(Standard_Integer), 1, myStream))
-    throw Storage_StreamTypeMismatchError();
+    SetErrorStatus(Storage_VSTypeMismatch);
 #if OCCT_BINARY_FILE_DO_INVERSE
   aValue = InverseInt(aValue);
 #endif
@@ -390,7 +390,7 @@ void FSD_BinaryFile::GetInteger(Standard_IStream& theIStream, Standard_Integer& 
 
   if (theIStream.gcount() != sizeof(Standard_Integer))
   {
-    throw Storage_StreamTypeMismatchError();
+    SetErrorStatus(Storage_VSTypeMismatch);
   }
 
 #if OCCT_BINARY_FILE_DO_INVERSE
@@ -404,7 +404,7 @@ Storage_BaseDriver& FSD_BinaryFile::GetBoolean(Standard_Boolean& aValue)
 {
   Standard_Integer anInt = 0;
   if (!fread(&anInt, sizeof(Standard_Integer), 1, myStream))
-    throw Storage_StreamTypeMismatchError();
+    SetErrorStatus(Storage_VSTypeMismatch);
 #if OCCT_BINARY_FILE_DO_INVERSE
   anInt = InverseInt(anInt);
 #endif
@@ -417,7 +417,7 @@ Storage_BaseDriver& FSD_BinaryFile::GetBoolean(Standard_Boolean& aValue)
 Storage_BaseDriver& FSD_BinaryFile::GetReal(Standard_Real& aValue)
 {
   if (!fread(&aValue, sizeof(Standard_Real), 1, myStream))
-    throw Storage_StreamTypeMismatchError();
+    SetErrorStatus(Storage_VSTypeMismatch);
 #if OCCT_BINARY_FILE_DO_INVERSE
   aValue = InverseReal(aValue);
 #endif
@@ -429,7 +429,7 @@ Storage_BaseDriver& FSD_BinaryFile::GetReal(Standard_Real& aValue)
 Storage_BaseDriver& FSD_BinaryFile::GetShortReal(Standard_ShortReal& aValue)
 {
   if (!fread(&aValue, sizeof(Standard_ShortReal), 1, myStream))
-    throw Storage_StreamTypeMismatchError();
+    SetErrorStatus(Storage_VSTypeMismatch);
 #if OCCT_BINARY_FILE_DO_INVERSE
   aValue = InverseShortReal(aValue);
 #endif
@@ -466,7 +466,7 @@ Storage_Error FSD_BinaryFile::BeginWriteInfoSection()
   myHeader.testindian = aWrapUnion.aResult;
 
   if (!fwrite(FSD_BinaryFile::MagicNumber(), strlen(FSD_BinaryFile::MagicNumber()), 1, myStream))
-    throw Storage_StreamWriteError();
+    SetErrorStatus(Storage_VSWriteError);
 
   myHeader.binfo = (Standard_Integer)ftell(myStream);
   WriteHeader();
@@ -1280,7 +1280,7 @@ void FSD_BinaryFile::WriteString(const TCollection_AsciiString& aString)
   if (size > 0)
   {
     if (!fwrite(aString.ToCString(), aString.Length(), 1, myStream))
-      throw Storage_StreamWriteError();
+      SetErrorStatus(Storage_VSWriteError);
   }
 }
 
@@ -1303,7 +1303,7 @@ Standard_Integer FSD_BinaryFile::WriteString(Standard_OStream&              theO
     theOStream.write(theString.ToCString(), theString.Length());
     if (theOStream.fail())
     {
-      throw Storage_StreamWriteError();
+      SetErrorStatus(Storage_VSWriteError);
     }
   }
 
@@ -1325,7 +1325,7 @@ void FSD_BinaryFile::ReadString(TCollection_AsciiString& aString)
     Standard_Character* c =
       (Standard_Character*)Standard::Allocate((size + 1) * sizeof(Standard_Character));
     if (!fread(c, size, 1, myStream))
-      throw Storage_StreamWriteError();
+      SetErrorStatus(Storage_VSWriteError);
     c[size] = '\0';
     aString = c;
     Standard::Free(c);
@@ -1353,14 +1353,14 @@ void FSD_BinaryFile::ReadString(Standard_IStream& theIStream, TCollection_AsciiS
 
     if (!theIStream.good())
     {
-      throw Storage_StreamReadError();
+      SetErrorStatus(Storage_VSFormatError); return;
     }
 
     theIStream.read(c, size);
 
     if (theIStream.gcount() != size)
     {
-      throw Storage_StreamReadError();
+      SetErrorStatus(Storage_VSFormatError); return;
     }
 
     c[size] = '\0';
@@ -1405,7 +1405,7 @@ void FSD_BinaryFile::WriteExtendedString(const TCollection_ExtendedString& aStri
     anExtStr = aString.ToExtString();
 #endif
     if (!fwrite(anExtStr, sizeof(Standard_ExtCharacter) * aString.Length(), 1, myStream))
-      throw Storage_StreamWriteError();
+      SetErrorStatus(Storage_VSWriteError);
   }
 }
 
@@ -1445,7 +1445,7 @@ Standard_Integer FSD_BinaryFile::WriteExtendedString(Standard_OStream&          
     theOStream.write((char*)anExtStr, sizeof(Standard_ExtCharacter) * theString.Length());
     if (theOStream.fail())
     {
-      throw Storage_StreamWriteError();
+      SetErrorStatus(Storage_VSWriteError);
     }
   }
 
@@ -1467,7 +1467,7 @@ void FSD_BinaryFile::ReadExtendedString(TCollection_ExtendedString& aString)
     Standard_ExtCharacter* c =
       (Standard_ExtCharacter*)Standard::Allocate((size + 1) * sizeof(Standard_ExtCharacter));
     if (!fread(c, size * sizeof(Standard_ExtCharacter), 1, myStream))
-      throw Storage_StreamWriteError();
+      SetErrorStatus(Storage_VSWriteError);
     c[size] = '\0';
 #if OCCT_BINARY_FILE_DO_INVERSE
     for (Standard_Integer i = 0; i < size; i++)
@@ -1500,14 +1500,14 @@ void FSD_BinaryFile::ReadExtendedString(Standard_IStream&           theIStream,
 
     if (!theIStream.good())
     {
-      throw Storage_StreamReadError();
+      SetErrorStatus(Storage_VSFormatError); return;
     }
 
     const std::streamsize aNbBytes = std::streamsize(sizeof(Standard_ExtCharacter) * size);
     theIStream.read((char*)c, aNbBytes);
     if (theIStream.gcount() != aNbBytes)
     {
-      throw Storage_StreamReadError();
+      SetErrorStatus(Storage_VSFormatError); return;
     }
 
     c[size] = '\0';

--- a/src/FoundationClasses/TKernel/FSD/FSD_CmpFile.cxx
+++ b/src/FoundationClasses/TKernel/FSD/FSD_CmpFile.cxx
@@ -241,7 +241,7 @@ Storage_Error FSD_CmpFile::BeginWriteInfoSection()
   myStream << FSD_CmpFile::MagicNumber() << '\n';
   myStream << "BEGIN_INFO_SECTION\n";
   if (myStream.bad())
-    throw Storage_StreamWriteError();
+    return Storage_VSWriteError;
 
   return Storage_VSOk;
 }
@@ -275,7 +275,10 @@ void FSD_CmpFile::WritePersistentObjectHeader(const Standard_Integer aRef,
 {
   myStream << "\n#" << aRef << "%" << aType << " ";
   if (myStream.bad())
-    throw Storage_StreamWriteError();
+  {
+    SetErrorStatus(Storage_VSWriteError);
+    return;
+  }
 }
 
 //=================================================================================================
@@ -283,7 +286,10 @@ void FSD_CmpFile::WritePersistentObjectHeader(const Standard_Integer aRef,
 void FSD_CmpFile::BeginWritePersistentObjectData()
 {
   if (myStream.bad())
-    throw Storage_StreamWriteError();
+  {
+    SetErrorStatus(Storage_VSWriteError);
+    return;
+  }
 }
 
 //=================================================================================================
@@ -291,7 +297,10 @@ void FSD_CmpFile::BeginWritePersistentObjectData()
 void FSD_CmpFile::BeginWriteObjectData()
 {
   if (myStream.bad())
-    throw Storage_StreamWriteError();
+  {
+    SetErrorStatus(Storage_VSWriteError);
+    return;
+  }
 }
 
 //=================================================================================================
@@ -299,7 +308,10 @@ void FSD_CmpFile::BeginWriteObjectData()
 void FSD_CmpFile::EndWriteObjectData()
 {
   if (myStream.bad())
-    throw Storage_StreamWriteError();
+  {
+    SetErrorStatus(Storage_VSWriteError);
+    return;
+  }
 }
 
 //=================================================================================================
@@ -307,7 +319,10 @@ void FSD_CmpFile::EndWriteObjectData()
 void FSD_CmpFile::EndWritePersistentObjectData()
 {
   if (myStream.bad())
-    throw Storage_StreamWriteError();
+  {
+    SetErrorStatus(Storage_VSWriteError);
+    return;
+  }
 }
 
 //=================================================================================================
@@ -322,13 +337,13 @@ void FSD_CmpFile::ReadPersistentObjectHeader(Standard_Integer& aRef, Standard_In
   {
     if (IsEnd() || (c != ' ') || (c == '\r') || (c == '\n'))
     {
-      throw Storage_StreamFormatError();
+      SetErrorStatus(Storage_VSFormatError); return Storage_VSOk;
     }
     myStream.get(c);
   }
 
   if (!(myStream >> aRef))
-    throw Storage_StreamTypeMismatchError();
+    SetErrorStatus(Storage_VSTypeMismatch); return Storage_VSOk;
 
   myStream.get(c);
 
@@ -336,13 +351,13 @@ void FSD_CmpFile::ReadPersistentObjectHeader(Standard_Integer& aRef, Standard_In
   {
     if (IsEnd() || (c != ' ') || (c == '\r') || (c == '\n'))
     {
-      throw Storage_StreamFormatError();
+      SetErrorStatus(Storage_VSFormatError); return Storage_VSOk;
     }
     myStream.get(c);
   }
 
   if (!(myStream >> aType))
-    throw Storage_StreamTypeMismatchError();
+    SetErrorStatus(Storage_VSTypeMismatch); return Storage_VSOk;
   //  std::cout << "REF:" << aRef << " TYPE:"<< aType << std::endl;
 }
 
@@ -378,7 +393,7 @@ void FSD_CmpFile::EndReadPersistentObjectData()
   {
     if (IsEnd() || (c != ' '))
     {
-      throw Storage_StreamFormatError();
+      SetErrorStatus(Storage_VSFormatError); return Storage_VSOk;
     }
     myStream.get(c);
   }

--- a/src/FoundationClasses/TKernel/FSD/FSD_CmpFile.cxx
+++ b/src/FoundationClasses/TKernel/FSD/FSD_CmpFile.cxx
@@ -337,13 +337,17 @@ void FSD_CmpFile::ReadPersistentObjectHeader(Standard_Integer& aRef, Standard_In
   {
     if (IsEnd() || (c != ' ') || (c == '\r') || (c == '\n'))
     {
-      SetErrorStatus(Storage_VSFormatError); return Storage_VSOk;
+      SetErrorStatus(Storage_VSFormatError);
+      return;
     }
     myStream.get(c);
   }
 
   if (!(myStream >> aRef))
-    SetErrorStatus(Storage_VSTypeMismatch); return Storage_VSOk;
+  {
+    SetErrorStatus(Storage_VSTypeMismatch);
+    return;
+  }
 
   myStream.get(c);
 
@@ -351,13 +355,17 @@ void FSD_CmpFile::ReadPersistentObjectHeader(Standard_Integer& aRef, Standard_In
   {
     if (IsEnd() || (c != ' ') || (c == '\r') || (c == '\n'))
     {
-      SetErrorStatus(Storage_VSFormatError); return Storage_VSOk;
+      SetErrorStatus(Storage_VSFormatError);
+      return;
     }
     myStream.get(c);
   }
 
   if (!(myStream >> aType))
-    SetErrorStatus(Storage_VSTypeMismatch); return Storage_VSOk;
+  {
+    SetErrorStatus(Storage_VSTypeMismatch);
+    return;
+  }
   //  std::cout << "REF:" << aRef << " TYPE:"<< aType << std::endl;
 }
 
@@ -393,7 +401,8 @@ void FSD_CmpFile::EndReadPersistentObjectData()
   {
     if (IsEnd() || (c != ' '))
     {
-      SetErrorStatus(Storage_VSFormatError); return Storage_VSOk;
+      SetErrorStatus(Storage_VSFormatError);
+      return;
     }
     myStream.get(c);
   }

--- a/src/FoundationClasses/TKernel/FSD/FSD_File.cxx
+++ b/src/FoundationClasses/TKernel/FSD/FSD_File.cxx
@@ -767,6 +767,7 @@ Storage_Error FSD_File::BeginWriteCommentSection()
   myStream << "BEGIN_COMMENT_SECTION\n";
   if (myStream.bad())
     return Storage_VSWriteError;
+  return Storage_VSOk;
 }
 
 //=================================================================================================
@@ -801,6 +802,7 @@ Storage_Error FSD_File::EndWriteCommentSection()
   myStream << "END_COMMENT_SECTION\n";
   if (myStream.bad())
     return Storage_VSWriteError;
+  return Storage_VSOk;
 }
 
 //=======================================================================
@@ -818,10 +820,13 @@ Storage_Error FSD_File::BeginReadCommentSection()
 void FSD_File::ReadComment(TColStd_SequenceOfExtendedString& aCom)
 {
   TCollection_ExtendedString line;
-  Standard_Integer           len, i;
+  Standard_Integer           len = 0, i;
 
   if (!(myStream >> len))
+  {
     SetErrorStatus(Storage_VSTypeMismatch);
+    return;
+  }
 
   FlushEndOfLine();
 
@@ -850,6 +855,7 @@ Storage_Error FSD_File::BeginWriteTypeSection()
   myStream << "BEGIN_TYPE_SECTION\n";
   if (myStream.bad())
     return Storage_VSWriteError;
+  return Storage_VSOk;
 }
 
 //=================================================================================================
@@ -884,6 +890,7 @@ Storage_Error FSD_File::EndWriteTypeSection()
   myStream << "END_TYPE_SECTION\n";
   if (myStream.bad())
     return Storage_VSWriteError;
+  return Storage_VSOk;
 }
 
 //=======================================================================
@@ -900,10 +907,13 @@ Storage_Error FSD_File::BeginReadTypeSection()
 
 Standard_Integer FSD_File::TypeSectionSize()
 {
-  Standard_Integer i;
+  Standard_Integer i = 0;
 
   if (!(myStream >> i))
+  {
     SetErrorStatus(Storage_VSTypeMismatch);
+    return 0;
+  }
 
   FlushEndOfLine();
 
@@ -948,6 +958,7 @@ Storage_Error FSD_File::BeginWriteRootSection()
   myStream << "BEGIN_ROOT_SECTION\n";
   if (myStream.bad())
     return Storage_VSWriteError;
+  return Storage_VSOk;
 }
 
 //=================================================================================================
@@ -983,6 +994,7 @@ Storage_Error FSD_File::EndWriteRootSection()
   myStream << "END_ROOT_SECTION\n";
   if (myStream.bad())
     return Storage_VSWriteError;
+  return Storage_VSOk;
 }
 
 //=======================================================================
@@ -999,10 +1011,13 @@ Storage_Error FSD_File::BeginReadRootSection()
 
 Standard_Integer FSD_File::RootSectionSize()
 {
-  Standard_Integer i;
+  Standard_Integer i = 0;
 
   if (!(myStream >> i))
+  {
     SetErrorStatus(Storage_VSTypeMismatch);
+    return 0;
+  }
 
   FlushEndOfLine();
 
@@ -1045,6 +1060,7 @@ Storage_Error FSD_File::BeginWriteRefSection()
   myStream << "BEGIN_REF_SECTION\n";
   if (myStream.bad())
     return Storage_VSWriteError;
+  return Storage_VSOk;
 }
 
 //=================================================================================================
@@ -1078,6 +1094,7 @@ Storage_Error FSD_File::EndWriteRefSection()
   myStream << "END_REF_SECTION\n";
   if (myStream.bad())
     return Storage_VSWriteError;
+  return Storage_VSOk;
 }
 
 //=======================================================================
@@ -1094,10 +1111,13 @@ Storage_Error FSD_File::BeginReadRefSection()
 
 Standard_Integer FSD_File::RefSectionSize()
 {
-  Standard_Integer i;
+  Standard_Integer i = 0;
 
   if (!(myStream >> i))
+  {
     SetErrorStatus(Storage_VSTypeMismatch);
+    return 0;
+  }
   FlushEndOfLine();
 
   return i;
@@ -1141,6 +1161,7 @@ Storage_Error FSD_File::BeginWriteDataSection()
   myStream << "BEGIN_DATA_SECTION";
   if (myStream.bad())
     return Storage_VSWriteError;
+  return Storage_VSOk;
 }
 
 //=================================================================================================

--- a/src/FoundationClasses/TKernel/FSD/FSD_File.cxx
+++ b/src/FoundationClasses/TKernel/FSD/FSD_File.cxx
@@ -766,8 +766,7 @@ Storage_Error FSD_File::BeginWriteCommentSection()
 {
   myStream << "BEGIN_COMMENT_SECTION\n";
   if (myStream.bad())
-    SetErrorStatus(Storage_VSWriteError);
-  return Storage_VSOk;
+    return Storage_VSWriteError;
 }
 
 //=================================================================================================
@@ -801,8 +800,7 @@ Storage_Error FSD_File::EndWriteCommentSection()
 {
   myStream << "END_COMMENT_SECTION\n";
   if (myStream.bad())
-    SetErrorStatus(Storage_VSWriteError);
-  return Storage_VSOk;
+    return Storage_VSWriteError;
 }
 
 //=======================================================================
@@ -851,8 +849,7 @@ Storage_Error FSD_File::BeginWriteTypeSection()
 {
   myStream << "BEGIN_TYPE_SECTION\n";
   if (myStream.bad())
-    SetErrorStatus(Storage_VSWriteError);
-  return Storage_VSOk;
+    return Storage_VSWriteError;
 }
 
 //=================================================================================================
@@ -886,8 +883,7 @@ Storage_Error FSD_File::EndWriteTypeSection()
 {
   myStream << "END_TYPE_SECTION\n";
   if (myStream.bad())
-    SetErrorStatus(Storage_VSWriteError);
-  return Storage_VSOk;
+    return Storage_VSWriteError;
 }
 
 //=======================================================================
@@ -951,8 +947,7 @@ Storage_Error FSD_File::BeginWriteRootSection()
 {
   myStream << "BEGIN_ROOT_SECTION\n";
   if (myStream.bad())
-    SetErrorStatus(Storage_VSWriteError);
-  return Storage_VSOk;
+    return Storage_VSWriteError;
 }
 
 //=================================================================================================
@@ -987,8 +982,7 @@ Storage_Error FSD_File::EndWriteRootSection()
 {
   myStream << "END_ROOT_SECTION\n";
   if (myStream.bad())
-    SetErrorStatus(Storage_VSWriteError);
-  return Storage_VSOk;
+    return Storage_VSWriteError;
 }
 
 //=======================================================================
@@ -1050,8 +1044,7 @@ Storage_Error FSD_File::BeginWriteRefSection()
 {
   myStream << "BEGIN_REF_SECTION\n";
   if (myStream.bad())
-    SetErrorStatus(Storage_VSWriteError);
-  return Storage_VSOk;
+    return Storage_VSWriteError;
 }
 
 //=================================================================================================
@@ -1084,8 +1077,7 @@ Storage_Error FSD_File::EndWriteRefSection()
 {
   myStream << "END_REF_SECTION\n";
   if (myStream.bad())
-    SetErrorStatus(Storage_VSWriteError);
-  return Storage_VSOk;
+    return Storage_VSWriteError;
 }
 
 //=======================================================================
@@ -1148,8 +1140,7 @@ Storage_Error FSD_File::BeginWriteDataSection()
 {
   myStream << "BEGIN_DATA_SECTION";
   if (myStream.bad())
-    SetErrorStatus(Storage_VSWriteError);
-  return Storage_VSOk;
+    return Storage_VSWriteError;
 }
 
 //=================================================================================================
@@ -1219,7 +1210,7 @@ Storage_Error FSD_File::EndWriteDataSection()
 {
   myStream << "\nEND_DATA_SECTION\n";
   if (myStream.bad())
-    SetErrorStatus(Storage_VSWriteError);
+    return Storage_VSWriteError;
   return Storage_VSOk;
 }
 
@@ -1246,12 +1237,16 @@ void FSD_File::ReadPersistentObjectHeader(Standard_Integer& aRef, Standard_Integ
     if (IsEnd() || (c != ' ') || (c == '\n'))
     {
       SetErrorStatus(Storage_VSFormatError);
+      return;
     }
     myStream.get(c);
   }
 
   if (!(myStream >> aRef))
+  {
     SetErrorStatus(Storage_VSTypeMismatch);
+    return;
+  }
 
   myStream.get(c);
 
@@ -1260,6 +1255,7 @@ void FSD_File::ReadPersistentObjectHeader(Standard_Integer& aRef, Standard_Integ
     if (IsEnd() || (c != ' ') || (c == '\n'))
     {
       SetErrorStatus(Storage_VSFormatError);
+      return;
     }
     myStream.get(c);
   }
@@ -1271,12 +1267,16 @@ void FSD_File::ReadPersistentObjectHeader(Standard_Integer& aRef, Standard_Integ
     if (IsEnd() || (c != ' ') || (c == '\n'))
     {
       SetErrorStatus(Storage_VSFormatError);
+      return;
     }
     myStream.get(c);
   }
 
   if (!(myStream >> aType))
+  {
     SetErrorStatus(Storage_VSTypeMismatch);
+    return;
+  }
   //  std::cout << "REF:" << aRef << " TYPE:"<< aType << std::endl;
 }
 
@@ -1291,6 +1291,7 @@ void FSD_File::BeginReadPersistentObjectData()
     if (IsEnd() || (c != ' ') || (c == '\n'))
     {
       SetErrorStatus(Storage_VSFormatError);
+      return;
     }
     myStream.get(c);
   }
@@ -1309,6 +1310,7 @@ void FSD_File::BeginReadObjectData()
     if (IsEnd() || (c != ' ') || (c == '\n'))
     {
       SetErrorStatus(Storage_VSFormatError);
+      return;
     }
     myStream.get(c);
   }
@@ -1327,6 +1329,7 @@ void FSD_File::EndReadObjectData()
     if (IsEnd() || (c != ' ') || (c == '\n'))
     {
       SetErrorStatus(Storage_VSFormatError);
+      return;
     }
     myStream.get(c);
   }
@@ -1346,6 +1349,7 @@ void FSD_File::EndReadPersistentObjectData()
     if (IsEnd() || (c != ' ') || (c == '\n'))
     {
       SetErrorStatus(Storage_VSFormatError);
+      return;
     }
     myStream.get(c);
   }
@@ -1356,6 +1360,7 @@ void FSD_File::EndReadPersistentObjectData()
     if (IsEnd() || (c != ' '))
     {
       SetErrorStatus(Storage_VSFormatError);
+      return;
     }
     myStream.get(c);
   }

--- a/src/FoundationClasses/TKernel/Storage/Storage_BaseDriver.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_BaseDriver.cxx
@@ -13,7 +13,6 @@
 // commercial license or contractual agreement.
 
 #include <Storage_BaseDriver.hxx>
-#include <Storage_StreamExtCharParityError.hxx>
 #include <TCollection_AsciiString.hxx>
 #include <TCollection_ExtendedString.hxx>
 

--- a/src/FoundationClasses/TKernel/Storage/Storage_BaseDriver.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_BaseDriver.cxx
@@ -20,7 +20,8 @@
 IMPLEMENT_STANDARD_RTTIEXT(Storage_BaseDriver, Standard_Transient)
 
 Storage_BaseDriver::Storage_BaseDriver()
-    : myOpenMode(Storage_VSNone)
+    : myOpenMode(Storage_VSNone),
+      myErrorStatus(Storage_VSOk)
 {
 }
 

--- a/src/FoundationClasses/TKernel/Storage/Storage_BaseDriver.hxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_BaseDriver.hxx
@@ -194,6 +194,26 @@ public:
   Standard_EXPORT virtual Storage_Error Close() = 0;
 
 public:
+  //!@name Error state management
+
+  //! Returns the error status of the last operation.
+  Storage_Error ErrorStatus() const { return myErrorStatus; }
+
+  //! Clears the error status.
+  void ClearErrorStatus() { myErrorStatus = Storage_VSOk; myErrorStatusExt.Clear(); }
+
+  //! Returns the extended error description.
+  const TCollection_AsciiString& ErrorStatusExtension() const { return myErrorStatusExt; }
+
+protected:
+  //! Sets the error status.
+  void SetErrorStatus(const Storage_Error theError, const TCollection_AsciiString& theExtension = TCollection_AsciiString())
+  {
+    myErrorStatus = theError;
+    myErrorStatusExt = theExtension;
+  }
+
+public:
   //!@name Output methods
 
   Standard_EXPORT virtual Storage_BaseDriver& PutReference(const Standard_Integer aValue) = 0;
@@ -265,6 +285,8 @@ protected:
 private:
   Storage_OpenMode        myOpenMode;
   TCollection_AsciiString myName;
+  Storage_Error           myErrorStatus;
+  TCollection_AsciiString myErrorStatusExt;
 };
 
 #endif // _Storage_BaseDriver_HeaderFile

--- a/src/FoundationClasses/TKernel/Storage/Storage_BaseDriver.hxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_BaseDriver.hxx
@@ -195,6 +195,9 @@ public:
 
 public:
   //!@name Error state management
+  //!
+  //! @warning Driver instances are NOT thread-safe and should not be shared across threads.
+  //! Each thread should use its own driver instance for file I/O operations.
 
   //! Returns the error status of the last operation.
   Storage_Error ErrorStatus() const { return myErrorStatus; }

--- a/src/FoundationClasses/TKernel/Storage/Storage_BaseDriver.hxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_BaseDriver.hxx
@@ -200,16 +200,21 @@ public:
   Storage_Error ErrorStatus() const { return myErrorStatus; }
 
   //! Clears the error status.
-  void ClearErrorStatus() { myErrorStatus = Storage_VSOk; myErrorStatusExt.Clear(); }
+  void ClearErrorStatus()
+  {
+    myErrorStatus = Storage_VSOk;
+    myErrorStatusExt.Clear();
+  }
 
   //! Returns the extended error description.
   const TCollection_AsciiString& ErrorStatusExtension() const { return myErrorStatusExt; }
 
 protected:
   //! Sets the error status.
-  void SetErrorStatus(const Storage_Error theError, const TCollection_AsciiString& theExtension = TCollection_AsciiString())
+  void SetErrorStatus(const Storage_Error            theError,
+                      const TCollection_AsciiString& theExtension = TCollection_AsciiString())
   {
-    myErrorStatus = theError;
+    myErrorStatus    = theError;
     myErrorStatusExt = theExtension;
   }
 

--- a/src/FoundationClasses/TKernel/Storage/Storage_HeaderData.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_HeaderData.cxx
@@ -55,14 +55,13 @@ Standard_Boolean Storage_HeaderData::Read(const Handle(Storage_BaseDriver)& theD
                         myApplicationVersion,
                         myDataType,
                         myUserInfo);
+  }
 
-    // Check for errors from the driver
-    if (theDriver->ErrorStatus() != Storage_VSOk)
-    {
-      myErrorStatus    = theDriver->ErrorStatus();
-      myErrorStatusExt = "ReadInfo";
-      return Standard_False;
-    }
+  if (theDriver->ErrorStatus() != Storage_VSOk)
+  {
+    myErrorStatus    = theDriver->ErrorStatus();
+    myErrorStatusExt = "ReadInfo";
+    return Standard_False;
   }
 
   myErrorStatus = theDriver->EndReadInfoSection();
@@ -83,14 +82,13 @@ Standard_Boolean Storage_HeaderData::Read(const Handle(Storage_BaseDriver)& theD
   {
     OCC_CATCH_SIGNALS
     theDriver->ReadComment(myComments);
+  }
 
-    // Check for errors from the driver
-    if (theDriver->ErrorStatus() != Storage_VSOk)
-    {
-      myErrorStatus    = theDriver->ErrorStatus();
-      myErrorStatusExt = "ReadComment";
-      return Standard_False;
-    }
+  if (theDriver->ErrorStatus() != Storage_VSOk)
+  {
+    myErrorStatus    = theDriver->ErrorStatus();
+    myErrorStatusExt = "ReadComment";
+    return Standard_False;
   }
 
   myErrorStatus = theDriver->EndReadCommentSection();

--- a/src/FoundationClasses/TKernel/Storage/Storage_HeaderData.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_HeaderData.cxx
@@ -15,8 +15,6 @@
 #include <Standard_ErrorHandler.hxx>
 #include <Storage_HeaderData.hxx>
 #include <Storage_BaseDriver.hxx>
-#include <Storage_StreamTypeMismatchError.hxx>
-#include <Storage_StreamExtCharParityError.hxx>
 #include <TCollection_AsciiString.hxx>
 #include <TCollection_ExtendedString.hxx>
 

--- a/src/FoundationClasses/TKernel/Storage/Storage_HeaderData.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_HeaderData.cxx
@@ -45,7 +45,6 @@ Standard_Boolean Storage_HeaderData::Read(const Handle(Storage_BaseDriver)& theD
   }
 
   {
-    OCC_CATCH_SIGNALS
     theDriver->ReadInfo(myNBObj,
                         myStorageVersion,
                         myDate,
@@ -80,7 +79,6 @@ Standard_Boolean Storage_HeaderData::Read(const Handle(Storage_BaseDriver)& theD
   }
 
   {
-    OCC_CATCH_SIGNALS
     theDriver->ReadComment(myComments);
   }
 

--- a/src/FoundationClasses/TKernel/Storage/Storage_HeaderData.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_HeaderData.cxx
@@ -44,17 +44,15 @@ Standard_Boolean Storage_HeaderData::Read(const Handle(Storage_BaseDriver)& theD
     return Standard_False;
   }
 
-  {
-    theDriver->ReadInfo(myNBObj,
-                        myStorageVersion,
-                        myDate,
-                        mySchemaName,
-                        mySchemaVersion,
-                        myApplicationName,
-                        myApplicationVersion,
-                        myDataType,
-                        myUserInfo);
-  }
+  theDriver->ReadInfo(myNBObj,
+                      myStorageVersion,
+                      myDate,
+                      mySchemaName,
+                      mySchemaVersion,
+                      myApplicationName,
+                      myApplicationVersion,
+                      myDataType,
+                      myUserInfo);
 
   if (theDriver->ErrorStatus() != Storage_VSOk)
   {
@@ -78,9 +76,7 @@ Standard_Boolean Storage_HeaderData::Read(const Handle(Storage_BaseDriver)& theD
     return Standard_False;
   }
 
-  {
-    theDriver->ReadComment(myComments);
-  }
+  theDriver->ReadComment(myComments);
 
   if (theDriver->ErrorStatus() != Storage_VSOk)
   {

--- a/src/FoundationClasses/TKernel/Storage/Storage_HeaderData.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_HeaderData.cxx
@@ -59,7 +59,7 @@ Standard_Boolean Storage_HeaderData::Read(const Handle(Storage_BaseDriver)& theD
     // Check for errors from the driver
     if (theDriver->ErrorStatus() != Storage_VSOk)
     {
-      myErrorStatus = theDriver->ErrorStatus();
+      myErrorStatus    = theDriver->ErrorStatus();
       myErrorStatusExt = "ReadInfo";
       return Standard_False;
     }
@@ -87,7 +87,7 @@ Standard_Boolean Storage_HeaderData::Read(const Handle(Storage_BaseDriver)& theD
     // Check for errors from the driver
     if (theDriver->ErrorStatus() != Storage_VSOk)
     {
-      myErrorStatus = theDriver->ErrorStatus();
+      myErrorStatus    = theDriver->ErrorStatus();
       myErrorStatusExt = "ReadComment";
       return Standard_False;
     }

--- a/src/FoundationClasses/TKernel/Storage/Storage_HeaderData.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_HeaderData.cxx
@@ -47,28 +47,21 @@ Standard_Boolean Storage_HeaderData::Read(const Handle(Storage_BaseDriver)& theD
   }
 
   {
-    try
+    OCC_CATCH_SIGNALS
+    theDriver->ReadInfo(myNBObj,
+                        myStorageVersion,
+                        myDate,
+                        mySchemaName,
+                        mySchemaVersion,
+                        myApplicationName,
+                        myApplicationVersion,
+                        myDataType,
+                        myUserInfo);
+
+    // Check for errors from the driver
+    if (theDriver->ErrorStatus() != Storage_VSOk)
     {
-      OCC_CATCH_SIGNALS
-      theDriver->ReadInfo(myNBObj,
-                          myStorageVersion,
-                          myDate,
-                          mySchemaName,
-                          mySchemaVersion,
-                          myApplicationName,
-                          myApplicationVersion,
-                          myDataType,
-                          myUserInfo);
-    }
-    catch (Storage_StreamTypeMismatchError const&)
-    {
-      myErrorStatus    = Storage_VSTypeMismatch;
-      myErrorStatusExt = "ReadInfo";
-      return Standard_False;
-    }
-    catch (Storage_StreamExtCharParityError const&)
-    {
-      myErrorStatus    = Storage_VSExtCharParityError;
+      myErrorStatus = theDriver->ErrorStatus();
       myErrorStatusExt = "ReadInfo";
       return Standard_False;
     }
@@ -90,20 +83,13 @@ Standard_Boolean Storage_HeaderData::Read(const Handle(Storage_BaseDriver)& theD
   }
 
   {
-    try
+    OCC_CATCH_SIGNALS
+    theDriver->ReadComment(myComments);
+
+    // Check for errors from the driver
+    if (theDriver->ErrorStatus() != Storage_VSOk)
     {
-      OCC_CATCH_SIGNALS
-      theDriver->ReadComment(myComments);
-    }
-    catch (Storage_StreamTypeMismatchError const&)
-    {
-      myErrorStatus    = Storage_VSTypeMismatch;
-      myErrorStatusExt = "ReadComment";
-      return Standard_False;
-    }
-    catch (Storage_StreamExtCharParityError const&)
-    {
-      myErrorStatus    = Storage_VSExtCharParityError;
+      myErrorStatus = theDriver->ErrorStatus();
       myErrorStatusExt = "ReadComment";
       return Standard_False;
     }

--- a/src/FoundationClasses/TKernel/Storage/Storage_HeaderData.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_HeaderData.cxx
@@ -12,7 +12,6 @@
 // Alternatively, this file may be used under the terms of Open CASCADE
 // commercial license or contractual agreement.
 
-#include <Standard_ErrorHandler.hxx>
 #include <Storage_HeaderData.hxx>
 #include <Storage_BaseDriver.hxx>
 #include <TCollection_AsciiString.hxx>

--- a/src/FoundationClasses/TKernel/Storage/Storage_RootData.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_RootData.cxx
@@ -52,9 +52,7 @@ Standard_Boolean Storage_RootData::Read(const Handle(Storage_BaseDriver)& theDri
   Standard_Integer len = theDriver->RootSectionSize();
   for (Standard_Integer i = 1; i <= len; i++)
   {
-    {
-      theDriver->ReadRoot(aRootName, aRef, aTypeName);
-    }
+    theDriver->ReadRoot(aRootName, aRef, aTypeName);
 
     if (theDriver->ErrorStatus() != Storage_VSOk)
     {

--- a/src/FoundationClasses/TKernel/Storage/Storage_RootData.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_RootData.cxx
@@ -52,17 +52,11 @@ Standard_Boolean Storage_RootData::Read(const Handle(Storage_BaseDriver)& theDri
   Standard_Integer len = theDriver->RootSectionSize();
   for (Standard_Integer i = 1; i <= len; i++)
   {
-    try
     {
       OCC_CATCH_SIGNALS
       theDriver->ReadRoot(aRootName, aRef, aTypeName);
     }
-    catch (Storage_StreamTypeMismatchError const&)
-    {
-      myErrorStatus    = Storage_VSTypeMismatch;
-      myErrorStatusExt = "ReadRoot";
-      return Standard_False;
-    }
+    
 
     Handle(Storage_Root) aRoot = new Storage_Root(aRootName, aRef, aTypeName);
     myObjects.Bind(aRootName, aRoot);

--- a/src/FoundationClasses/TKernel/Storage/Storage_RootData.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_RootData.cxx
@@ -56,6 +56,13 @@ Standard_Boolean Storage_RootData::Read(const Handle(Storage_BaseDriver)& theDri
       theDriver->ReadRoot(aRootName, aRef, aTypeName);
     }
 
+    if (theDriver->ErrorStatus() != Storage_VSOk)
+    {
+      myErrorStatus    = theDriver->ErrorStatus();
+      myErrorStatusExt = "ReadRoot";
+      return Standard_False;
+    }
+
     Handle(Storage_Root) aRoot = new Storage_Root(aRootName, aRef, aTypeName);
     myObjects.Bind(aRootName, aRoot);
   }

--- a/src/FoundationClasses/TKernel/Storage/Storage_RootData.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_RootData.cxx
@@ -53,7 +53,6 @@ Standard_Boolean Storage_RootData::Read(const Handle(Storage_BaseDriver)& theDri
   for (Standard_Integer i = 1; i <= len; i++)
   {
     {
-      OCC_CATCH_SIGNALS
       theDriver->ReadRoot(aRootName, aRef, aTypeName);
     }
 

--- a/src/FoundationClasses/TKernel/Storage/Storage_RootData.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_RootData.cxx
@@ -56,7 +56,6 @@ Standard_Boolean Storage_RootData::Read(const Handle(Storage_BaseDriver)& theDri
       OCC_CATCH_SIGNALS
       theDriver->ReadRoot(aRootName, aRef, aTypeName);
     }
-    
 
     Handle(Storage_Root) aRoot = new Storage_Root(aRootName, aRef, aTypeName);
     myObjects.Bind(aRootName, aRoot);

--- a/src/FoundationClasses/TKernel/Storage/Storage_RootData.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_RootData.cxx
@@ -13,11 +13,9 @@
 // commercial license or contractual agreement.
 
 #include <Standard_Persistent.hxx>
-#include <Standard_ErrorHandler.hxx>
 #include <Storage_RootData.hxx>
 #include <Storage_Root.hxx>
 #include <Storage_BaseDriver.hxx>
-#include <Storage_StreamTypeMismatchError.hxx>
 #include <Storage_DataMapIteratorOfMapOfPers.hxx>
 #include <TCollection_AsciiString.hxx>
 

--- a/src/FoundationClasses/TKernel/Storage/Storage_Schema.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_Schema.cxx
@@ -486,6 +486,7 @@ void Storage_Schema::Write(const Handle(Storage_BaseDriver)& theDriver,
         if (!p.IsNull())
         {
           WFunc->Value(p->_typenum)->Write(p, theDriver, me);
+          CHECK_DRIVER_ERROR_AND_RETURN_IF_FAILED()
           p->_typenum = 0;
         }
         bit.Next();

--- a/src/FoundationClasses/TKernel/Storage/Storage_Schema.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_Schema.cxx
@@ -347,17 +347,17 @@ void Storage_Schema::Write(const Handle(Storage_BaseDriver)& theDriver,
   aData->HeaderData()->SetSchemaName(myName);
   aData->HeaderData()->SetSchemaVersion(myVersion);
 
-  // Helper macro to check driver error status after each operation
-  // and return early if an error occurred
-  #define CHECK_DRIVER_ERROR_AND_RETURN_IF_FAILED() \
-    if (theDriver->ErrorStatus() != Storage_VSOk) \
-    { \
-      aData->SetErrorStatus(theDriver->ErrorStatus()); \
-      aData->SetErrorStatusExtension(errorContext); \
-      iData->Clear(); \
-      Clear(); \
-      return; \
-    }
+// Helper macro to check driver error status after each operation
+// and return early if an error occurred
+#define CHECK_DRIVER_ERROR_AND_RETURN_IF_FAILED()                                                  \
+  if (theDriver->ErrorStatus() != Storage_VSOk)                                                    \
+  {                                                                                                \
+    aData->SetErrorStatus(theDriver->ErrorStatus());                                               \
+    aData->SetErrorStatusExtension(errorContext);                                                  \
+    iData->Clear();                                                                                \
+    Clear();                                                                                       \
+    return;                                                                                        \
+  }
 
   if ((theDriver->OpenMode() == Storage_VSWrite) || (theDriver->OpenMode() == Storage_VSReadWrite))
   {
@@ -502,8 +502,8 @@ void Storage_Schema::Write(const Handle(Storage_BaseDriver)& theDriver,
     aData->SetErrorStatusExtension("OpenMode");
   }
 
-  // Clean up the helper macro
-  #undef CHECK_DRIVER_ERROR_AND_RETURN_IF_FAILED
+// Clean up the helper macro
+#undef CHECK_DRIVER_ERROR_AND_RETURN_IF_FAILED
 
   iData->Clear();
   Clear();

--- a/src/FoundationClasses/TKernel/Storage/Storage_Schema.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_Schema.cxx
@@ -12,7 +12,6 @@
 // Alternatively, this file may be used under the terms of Open CASCADE
 // commercial license or contractual agreement.
 
-#include <Standard_ErrorHandler.hxx>
 #include <Standard_Type.hxx>
 #include <Storage.hxx>
 #include <Storage_BaseDriver.hxx>

--- a/src/FoundationClasses/TKernel/Storage/Storage_Schema.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_Schema.cxx
@@ -23,7 +23,6 @@
 #include <Storage_HSeqOfRoot.hxx>
 #include <Storage_Root.hxx>
 #include <Storage_Schema.hxx>
-#include <Storage_StreamWriteError.hxx>
 #include <Storage_TypeData.hxx>
 #include <Storage_TypedCallBack.hxx>
 #include <TCollection_AsciiString.hxx>
@@ -351,7 +350,6 @@ void Storage_Schema::Write(const Handle(Storage_BaseDriver)& theDriver,
 
   if ((theDriver->OpenMode() == Storage_VSWrite) || (theDriver->OpenMode() == Storage_VSReadWrite))
   {
-    try
     {
       OCC_CATCH_SIGNALS
       errorContext = "BeginWriteInfoSection";
@@ -460,9 +458,10 @@ void Storage_Schema::Write(const Handle(Storage_BaseDriver)& theDriver,
       errorContext = "EndWriteDataSection";
       theDriver->EndWriteDataSection();
     }
-    catch (Storage_StreamWriteError const&)
+
+    if (theDriver->ErrorStatus() != Storage_VSOk)
     {
-      aData->SetErrorStatus(Storage_VSWriteError);
+      aData->SetErrorStatus(theDriver->ErrorStatus());
       aData->SetErrorStatusExtension(errorContext);
     }
   }

--- a/src/FoundationClasses/TKernel/Storage/Storage_Schema.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_Schema.cxx
@@ -363,7 +363,6 @@ void Storage_Schema::Write(const Handle(Storage_BaseDriver)& theDriver,
   if ((theDriver->OpenMode() == Storage_VSWrite) || (theDriver->OpenMode() == Storage_VSReadWrite))
   {
     {
-      OCC_CATCH_SIGNALS
       errorContext = "BeginWriteInfoSection";
       theDriver->BeginWriteInfoSection();
       CHECK_DRIVER_ERROR_AND_RETURN_IF_FAILED()

--- a/src/FoundationClasses/TKernel/Storage/Storage_StreamExtCharParityError.hxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_StreamExtCharParityError.hxx
@@ -25,8 +25,8 @@
 //! @deprecated OCCT 7.9.0 - This exception is deprecated and no longer thrown.
 //! Error handling is now performed via Storage_Error enum and error state management
 //! through Storage_BaseDriver::ErrorStatus() instead of exceptions.
-class Standard_DEPRECATED(
-  "This exception is no longer thrown; use Storage_BaseDriver::ErrorStatus() for error state management")
+class Standard_DEPRECATED("This exception is no longer thrown; use "
+                          "Storage_BaseDriver::ErrorStatus() for error state management")
   Storage_StreamExtCharParityError;
 DEFINE_STANDARD_HANDLE(Storage_StreamExtCharParityError, Storage_StreamReadError)
 

--- a/src/FoundationClasses/TKernel/Storage/Storage_StreamExtCharParityError.hxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_StreamExtCharParityError.hxx
@@ -22,11 +22,14 @@
 #include <Standard_SStream.hxx>
 #include <Storage_StreamReadError.hxx>
 
-//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
-class Storage_StreamExtCharParityError;
+//! @deprecated OCCT 7.9.0 - This exception is deprecated and no longer thrown.
+//! Error handling is now performed via Storage_Error enum and error state management
+//! through Storage_BaseDriver::ErrorStatus() instead of exceptions.
+class Standard_DEPRECATED(
+  "This exception is no longer thrown; use Storage_BaseDriver::ErrorStatus() for error state management")
+  Storage_StreamExtCharParityError;
 DEFINE_STANDARD_HANDLE(Storage_StreamExtCharParityError, Storage_StreamReadError)
 
-//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
 #if !defined No_Exception && !defined No_Storage_StreamExtCharParityError
   #define Storage_StreamExtCharParityError_Raise_if(CONDITION, MESSAGE)                            \
     if (CONDITION)                                                                                 \
@@ -35,7 +38,6 @@ DEFINE_STANDARD_HANDLE(Storage_StreamExtCharParityError, Storage_StreamReadError
   #define Storage_StreamExtCharParityError_Raise_if(CONDITION, MESSAGE)
 #endif
 
-//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
 DEFINE_STANDARD_EXCEPTION(Storage_StreamExtCharParityError, Storage_StreamReadError)
 
 #endif // _Storage_StreamExtCharParityError_HeaderFile

--- a/src/FoundationClasses/TKernel/Storage/Storage_StreamExtCharParityError.hxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_StreamExtCharParityError.hxx
@@ -22,9 +22,11 @@
 #include <Standard_SStream.hxx>
 #include <Storage_StreamReadError.hxx>
 
+//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
 class Storage_StreamExtCharParityError;
 DEFINE_STANDARD_HANDLE(Storage_StreamExtCharParityError, Storage_StreamReadError)
 
+//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
 #if !defined No_Exception && !defined No_Storage_StreamExtCharParityError
   #define Storage_StreamExtCharParityError_Raise_if(CONDITION, MESSAGE)                            \
     if (CONDITION)                                                                                 \
@@ -33,6 +35,7 @@ DEFINE_STANDARD_HANDLE(Storage_StreamExtCharParityError, Storage_StreamReadError
   #define Storage_StreamExtCharParityError_Raise_if(CONDITION, MESSAGE)
 #endif
 
+//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
 DEFINE_STANDARD_EXCEPTION(Storage_StreamExtCharParityError, Storage_StreamReadError)
 
 #endif // _Storage_StreamExtCharParityError_HeaderFile

--- a/src/FoundationClasses/TKernel/Storage/Storage_StreamFormatError.hxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_StreamFormatError.hxx
@@ -25,8 +25,8 @@
 //! @deprecated OCCT 7.9.0 - This exception is deprecated and no longer thrown.
 //! Error handling is now performed via Storage_Error enum and error state management
 //! through Storage_BaseDriver::ErrorStatus() instead of exceptions.
-class Standard_DEPRECATED(
-  "This exception is no longer thrown; use Storage_BaseDriver::ErrorStatus() for error state management")
+class Standard_DEPRECATED("This exception is no longer thrown; use "
+                          "Storage_BaseDriver::ErrorStatus() for error state management")
   Storage_StreamFormatError;
 DEFINE_STANDARD_HANDLE(Storage_StreamFormatError, Standard_Failure)
 

--- a/src/FoundationClasses/TKernel/Storage/Storage_StreamFormatError.hxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_StreamFormatError.hxx
@@ -22,9 +22,11 @@
 #include <Standard_SStream.hxx>
 #include <Standard_Failure.hxx>
 
+//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
 class Storage_StreamFormatError;
 DEFINE_STANDARD_HANDLE(Storage_StreamFormatError, Standard_Failure)
 
+//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
 #if !defined No_Exception && !defined No_Storage_StreamFormatError
   #define Storage_StreamFormatError_Raise_if(CONDITION, MESSAGE)                                   \
     if (CONDITION)                                                                                 \
@@ -33,6 +35,7 @@ DEFINE_STANDARD_HANDLE(Storage_StreamFormatError, Standard_Failure)
   #define Storage_StreamFormatError_Raise_if(CONDITION, MESSAGE)
 #endif
 
+//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
 DEFINE_STANDARD_EXCEPTION(Storage_StreamFormatError, Standard_Failure)
 
 #endif // _Storage_StreamFormatError_HeaderFile

--- a/src/FoundationClasses/TKernel/Storage/Storage_StreamFormatError.hxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_StreamFormatError.hxx
@@ -22,11 +22,14 @@
 #include <Standard_SStream.hxx>
 #include <Standard_Failure.hxx>
 
-//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
-class Storage_StreamFormatError;
+//! @deprecated OCCT 7.9.0 - This exception is deprecated and no longer thrown.
+//! Error handling is now performed via Storage_Error enum and error state management
+//! through Storage_BaseDriver::ErrorStatus() instead of exceptions.
+class Standard_DEPRECATED(
+  "This exception is no longer thrown; use Storage_BaseDriver::ErrorStatus() for error state management")
+  Storage_StreamFormatError;
 DEFINE_STANDARD_HANDLE(Storage_StreamFormatError, Standard_Failure)
 
-//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
 #if !defined No_Exception && !defined No_Storage_StreamFormatError
   #define Storage_StreamFormatError_Raise_if(CONDITION, MESSAGE)                                   \
     if (CONDITION)                                                                                 \
@@ -35,7 +38,6 @@ DEFINE_STANDARD_HANDLE(Storage_StreamFormatError, Standard_Failure)
   #define Storage_StreamFormatError_Raise_if(CONDITION, MESSAGE)
 #endif
 
-//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
 DEFINE_STANDARD_EXCEPTION(Storage_StreamFormatError, Standard_Failure)
 
 #endif // _Storage_StreamFormatError_HeaderFile

--- a/src/FoundationClasses/TKernel/Storage/Storage_StreamReadError.hxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_StreamReadError.hxx
@@ -22,9 +22,11 @@
 #include <Standard_SStream.hxx>
 #include <Standard_Failure.hxx>
 
+//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
 class Storage_StreamReadError;
 DEFINE_STANDARD_HANDLE(Storage_StreamReadError, Standard_Failure)
 
+//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
 #if !defined No_Exception && !defined No_Storage_StreamReadError
   #define Storage_StreamReadError_Raise_if(CONDITION, MESSAGE)                                     \
     if (CONDITION)                                                                                 \
@@ -33,6 +35,7 @@ DEFINE_STANDARD_HANDLE(Storage_StreamReadError, Standard_Failure)
   #define Storage_StreamReadError_Raise_if(CONDITION, MESSAGE)
 #endif
 
+//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
 DEFINE_STANDARD_EXCEPTION(Storage_StreamReadError, Standard_Failure)
 
 #endif // _Storage_StreamReadError_HeaderFile

--- a/src/FoundationClasses/TKernel/Storage/Storage_StreamReadError.hxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_StreamReadError.hxx
@@ -25,8 +25,8 @@
 //! @deprecated OCCT 7.9.0 - This exception is deprecated and no longer thrown.
 //! Error handling is now performed via Storage_Error enum and error state management
 //! through Storage_BaseDriver::ErrorStatus() instead of exceptions.
-class Standard_DEPRECATED(
-  "This exception is no longer thrown; use Storage_BaseDriver::ErrorStatus() for error state management")
+class Standard_DEPRECATED("This exception is no longer thrown; use "
+                          "Storage_BaseDriver::ErrorStatus() for error state management")
   Storage_StreamReadError;
 DEFINE_STANDARD_HANDLE(Storage_StreamReadError, Standard_Failure)
 

--- a/src/FoundationClasses/TKernel/Storage/Storage_StreamReadError.hxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_StreamReadError.hxx
@@ -22,11 +22,14 @@
 #include <Standard_SStream.hxx>
 #include <Standard_Failure.hxx>
 
-//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
-class Storage_StreamReadError;
+//! @deprecated OCCT 7.9.0 - This exception is deprecated and no longer thrown.
+//! Error handling is now performed via Storage_Error enum and error state management
+//! through Storage_BaseDriver::ErrorStatus() instead of exceptions.
+class Standard_DEPRECATED(
+  "This exception is no longer thrown; use Storage_BaseDriver::ErrorStatus() for error state management")
+  Storage_StreamReadError;
 DEFINE_STANDARD_HANDLE(Storage_StreamReadError, Standard_Failure)
 
-//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
 #if !defined No_Exception && !defined No_Storage_StreamReadError
   #define Storage_StreamReadError_Raise_if(CONDITION, MESSAGE)                                     \
     if (CONDITION)                                                                                 \
@@ -35,7 +38,6 @@ DEFINE_STANDARD_HANDLE(Storage_StreamReadError, Standard_Failure)
   #define Storage_StreamReadError_Raise_if(CONDITION, MESSAGE)
 #endif
 
-//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
 DEFINE_STANDARD_EXCEPTION(Storage_StreamReadError, Standard_Failure)
 
 #endif // _Storage_StreamReadError_HeaderFile

--- a/src/FoundationClasses/TKernel/Storage/Storage_StreamTypeMismatchError.hxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_StreamTypeMismatchError.hxx
@@ -22,9 +22,11 @@
 #include <Standard_SStream.hxx>
 #include <Storage_StreamReadError.hxx>
 
+//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
 class Storage_StreamTypeMismatchError;
 DEFINE_STANDARD_HANDLE(Storage_StreamTypeMismatchError, Storage_StreamReadError)
 
+//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
 #if !defined No_Exception && !defined No_Storage_StreamTypeMismatchError
   #define Storage_StreamTypeMismatchError_Raise_if(CONDITION, MESSAGE)                             \
     if (CONDITION)                                                                                 \
@@ -33,6 +35,7 @@ DEFINE_STANDARD_HANDLE(Storage_StreamTypeMismatchError, Storage_StreamReadError)
   #define Storage_StreamTypeMismatchError_Raise_if(CONDITION, MESSAGE)
 #endif
 
+//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
 DEFINE_STANDARD_EXCEPTION(Storage_StreamTypeMismatchError, Storage_StreamReadError)
 
 #endif // _Storage_StreamTypeMismatchError_HeaderFile

--- a/src/FoundationClasses/TKernel/Storage/Storage_StreamTypeMismatchError.hxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_StreamTypeMismatchError.hxx
@@ -25,8 +25,8 @@
 //! @deprecated OCCT 7.9.0 - This exception is deprecated and no longer thrown.
 //! Error handling is now performed via Storage_Error enum and error state management
 //! through Storage_BaseDriver::ErrorStatus() instead of exceptions.
-class Standard_DEPRECATED(
-  "This exception is no longer thrown; use Storage_BaseDriver::ErrorStatus() for error state management")
+class Standard_DEPRECATED("This exception is no longer thrown; use "
+                          "Storage_BaseDriver::ErrorStatus() for error state management")
   Storage_StreamTypeMismatchError;
 DEFINE_STANDARD_HANDLE(Storage_StreamTypeMismatchError, Storage_StreamReadError)
 

--- a/src/FoundationClasses/TKernel/Storage/Storage_StreamTypeMismatchError.hxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_StreamTypeMismatchError.hxx
@@ -22,11 +22,14 @@
 #include <Standard_SStream.hxx>
 #include <Storage_StreamReadError.hxx>
 
-//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
-class Storage_StreamTypeMismatchError;
+//! @deprecated OCCT 7.9.0 - This exception is deprecated and no longer thrown.
+//! Error handling is now performed via Storage_Error enum and error state management
+//! through Storage_BaseDriver::ErrorStatus() instead of exceptions.
+class Standard_DEPRECATED(
+  "This exception is no longer thrown; use Storage_BaseDriver::ErrorStatus() for error state management")
+  Storage_StreamTypeMismatchError;
 DEFINE_STANDARD_HANDLE(Storage_StreamTypeMismatchError, Storage_StreamReadError)
 
-//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
 #if !defined No_Exception && !defined No_Storage_StreamTypeMismatchError
   #define Storage_StreamTypeMismatchError_Raise_if(CONDITION, MESSAGE)                             \
     if (CONDITION)                                                                                 \
@@ -35,7 +38,6 @@ DEFINE_STANDARD_HANDLE(Storage_StreamTypeMismatchError, Storage_StreamReadError)
   #define Storage_StreamTypeMismatchError_Raise_if(CONDITION, MESSAGE)
 #endif
 
-//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
 DEFINE_STANDARD_EXCEPTION(Storage_StreamTypeMismatchError, Storage_StreamReadError)
 
 #endif // _Storage_StreamTypeMismatchError_HeaderFile

--- a/src/FoundationClasses/TKernel/Storage/Storage_StreamWriteError.hxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_StreamWriteError.hxx
@@ -25,8 +25,8 @@
 //! @deprecated OCCT 7.9.0 - This exception is deprecated and no longer thrown.
 //! Error handling is now performed via Storage_Error enum and error state management
 //! through Storage_BaseDriver::ErrorStatus() instead of exceptions.
-class Standard_DEPRECATED(
-  "This exception is no longer thrown; use Storage_BaseDriver::ErrorStatus() for error state management")
+class Standard_DEPRECATED("This exception is no longer thrown; use "
+                          "Storage_BaseDriver::ErrorStatus() for error state management")
   Storage_StreamWriteError;
 DEFINE_STANDARD_HANDLE(Storage_StreamWriteError, Standard_Failure)
 

--- a/src/FoundationClasses/TKernel/Storage/Storage_StreamWriteError.hxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_StreamWriteError.hxx
@@ -22,11 +22,14 @@
 #include <Standard_SStream.hxx>
 #include <Standard_Failure.hxx>
 
-//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
-class Storage_StreamWriteError;
+//! @deprecated OCCT 7.9.0 - This exception is deprecated and no longer thrown.
+//! Error handling is now performed via Storage_Error enum and error state management
+//! through Storage_BaseDriver::ErrorStatus() instead of exceptions.
+class Standard_DEPRECATED(
+  "This exception is no longer thrown; use Storage_BaseDriver::ErrorStatus() for error state management")
+  Storage_StreamWriteError;
 DEFINE_STANDARD_HANDLE(Storage_StreamWriteError, Standard_Failure)
 
-//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
 #if !defined No_Exception && !defined No_Storage_StreamWriteError
   #define Storage_StreamWriteError_Raise_if(CONDITION, MESSAGE)                                    \
     if (CONDITION)                                                                                 \
@@ -35,7 +38,6 @@ DEFINE_STANDARD_HANDLE(Storage_StreamWriteError, Standard_Failure)
   #define Storage_StreamWriteError_Raise_if(CONDITION, MESSAGE)
 #endif
 
-//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
 DEFINE_STANDARD_EXCEPTION(Storage_StreamWriteError, Standard_Failure)
 
 #endif // _Storage_StreamWriteError_HeaderFile

--- a/src/FoundationClasses/TKernel/Storage/Storage_StreamWriteError.hxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_StreamWriteError.hxx
@@ -22,9 +22,11 @@
 #include <Standard_SStream.hxx>
 #include <Standard_Failure.hxx>
 
+//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
 class Storage_StreamWriteError;
 DEFINE_STANDARD_HANDLE(Storage_StreamWriteError, Standard_Failure)
 
+//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
 #if !defined No_Exception && !defined No_Storage_StreamWriteError
   #define Storage_StreamWriteError_Raise_if(CONDITION, MESSAGE)                                    \
     if (CONDITION)                                                                                 \
@@ -33,6 +35,7 @@ DEFINE_STANDARD_HANDLE(Storage_StreamWriteError, Standard_Failure)
   #define Storage_StreamWriteError_Raise_if(CONDITION, MESSAGE)
 #endif
 
+//! @deprecated Deprecated in OCCT. Use Storage_Error enum and error state management instead.
 DEFINE_STANDARD_EXCEPTION(Storage_StreamWriteError, Standard_Failure)
 
 #endif // _Storage_StreamWriteError_HeaderFile

--- a/src/FoundationClasses/TKernel/Storage/Storage_TypeData.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_TypeData.cxx
@@ -48,9 +48,7 @@ Standard_Boolean Storage_TypeData::Read(const Handle(Storage_BaseDriver)& theDri
   Standard_Integer len = theDriver->TypeSectionSize();
   for (Standard_Integer i = 1; i <= len; i++)
   {
-    {
-      theDriver->ReadTypeInformations(aTypeNum, aTypeName);
-    }
+    theDriver->ReadTypeInformations(aTypeNum, aTypeName);
 
     if (theDriver->ErrorStatus() != Storage_VSOk)
     {

--- a/src/FoundationClasses/TKernel/Storage/Storage_TypeData.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_TypeData.cxx
@@ -12,7 +12,6 @@
 // Alternatively, this file may be used under the terms of Open CASCADE
 // commercial license or contractual agreement.
 
-#include <Standard_ErrorHandler.hxx>
 #include <Storage_TypeData.hxx>
 #include <Storage_BaseDriver.hxx>
 #include <TCollection_AsciiString.hxx>

--- a/src/FoundationClasses/TKernel/Storage/Storage_TypeData.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_TypeData.cxx
@@ -15,7 +15,6 @@
 #include <Standard_ErrorHandler.hxx>
 #include <Storage_TypeData.hxx>
 #include <Storage_BaseDriver.hxx>
-#include <Storage_StreamTypeMismatchError.hxx>
 #include <TCollection_AsciiString.hxx>
 
 IMPLEMENT_STANDARD_RTTIEXT(Storage_TypeData, Standard_Transient)
@@ -49,14 +48,14 @@ Standard_Boolean Storage_TypeData::Read(const Handle(Storage_BaseDriver)& theDri
   Standard_Integer len = theDriver->TypeSectionSize();
   for (Standard_Integer i = 1; i <= len; i++)
   {
-    try
     {
       OCC_CATCH_SIGNALS
       theDriver->ReadTypeInformations(aTypeNum, aTypeName);
     }
-    catch (const Storage_StreamTypeMismatchError&)
+
+    if (theDriver->ErrorStatus() != Storage_VSOk)
     {
-      myErrorStatus    = Storage_VSTypeMismatch;
+      myErrorStatus    = theDriver->ErrorStatus();
       myErrorStatusExt = "ReadTypeInformations";
       return Standard_False;
     }

--- a/src/FoundationClasses/TKernel/Storage/Storage_TypeData.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_TypeData.cxx
@@ -49,7 +49,6 @@ Standard_Boolean Storage_TypeData::Read(const Handle(Storage_BaseDriver)& theDri
   for (Standard_Integer i = 1; i <= len; i++)
   {
     {
-      OCC_CATCH_SIGNALS
       theDriver->ReadTypeInformations(aTypeNum, aTypeName);
     }
 

--- a/src/ModelingData/TKBRep/BinTools/BinTools.cxx
+++ b/src/ModelingData/TKBRep/BinTools/BinTools.cxx
@@ -82,12 +82,10 @@ Standard_OStream& BinTools::PutExtChar(Standard_OStream& OS, const Standard_ExtC
 
 Standard_IStream& BinTools::GetReal(Standard_IStream& theIS, Standard_Real& theValue)
 {
-  if (!theIS.read((char*)&theValue, sizeof(Standard_Real)))
-  {
-    throw Storage_StreamTypeMismatchError();
-  }
+  theIS.read((char*)&theValue, sizeof(Standard_Real));
 #ifdef DO_INVERSE
-  theValue = InverseReal(theValue);
+  if (theIS.good())
+    theValue = InverseReal(theValue);
 #endif
   return theIS;
 }
@@ -96,12 +94,10 @@ Standard_IStream& BinTools::GetReal(Standard_IStream& theIS, Standard_Real& theV
 
 Standard_IStream& BinTools::GetShortReal(Standard_IStream& theIS, Standard_ShortReal& theValue)
 {
-  if (!theIS.read((char*)&theValue, sizeof(Standard_ShortReal)))
-  {
-    throw Storage_StreamTypeMismatchError();
-  }
+  theIS.read((char*)&theValue, sizeof(Standard_ShortReal));
 #ifdef DO_INVERSE
-  theValue = InverseShortReal(theValue);
+  if (theIS.good())
+    theValue = InverseShortReal(theValue);
 #endif
   return theIS;
 }
@@ -110,10 +106,10 @@ Standard_IStream& BinTools::GetShortReal(Standard_IStream& theIS, Standard_Short
 
 Standard_IStream& BinTools::GetInteger(Standard_IStream& IS, Standard_Integer& aValue)
 {
-  if (!IS.read((char*)&aValue, sizeof(Standard_Integer)))
-    throw Storage_StreamTypeMismatchError();
+  IS.read((char*)&aValue, sizeof(Standard_Integer));
 #ifdef DO_INVERSE
-  aValue = InverseInt(aValue);
+  if (IS.good())
+    aValue = InverseInt(aValue);
 #endif
   return IS;
 }
@@ -122,10 +118,10 @@ Standard_IStream& BinTools::GetInteger(Standard_IStream& IS, Standard_Integer& a
 
 Standard_IStream& BinTools::GetExtChar(Standard_IStream& IS, Standard_ExtCharacter& theValue)
 {
-  if (!IS.read((char*)&theValue, sizeof(Standard_ExtCharacter)))
-    throw Storage_StreamTypeMismatchError();
+  IS.read((char*)&theValue, sizeof(Standard_ExtCharacter));
 #ifdef DO_INVERSE
-  theValue = InverseExtChar(theValue);
+  if (IS.good())
+    theValue = InverseExtChar(theValue);
 #endif
   return IS;
 }

--- a/src/ModelingData/TKBRep/BinTools/BinTools_IStream.cxx
+++ b/src/ModelingData/TKBRep/BinTools/BinTools_IStream.cxx
@@ -136,7 +136,8 @@ BinTools_IStream& BinTools_IStream::operator>>(Standard_Real& theValue)
     myHasError = Standard_True;
   myPosition += sizeof(Standard_Real);
 #if DO_INVERSE
-  theValue = InverseReal(theValue);
+  if (!myHasError)
+    theValue = InverseReal(theValue);
 #endif
   return *this;
 }
@@ -151,7 +152,8 @@ BinTools_IStream& BinTools_IStream::operator>>(Standard_Integer& theValue)
     myHasError = Standard_True;
   myPosition += sizeof(Standard_Integer);
 #if DO_INVERSE
-  theValue = InverseInt(theValue);
+  if (!myHasError)
+    theValue = InverseInt(theValue);
 #endif
   return *this;
 }

--- a/src/ModelingData/TKBRep/BinTools/BinTools_IStream.cxx
+++ b/src/ModelingData/TKBRep/BinTools/BinTools_IStream.cxx
@@ -123,7 +123,7 @@ TopAbs_Orientation BinTools_IStream::ShapeOrientation()
 
 BinTools_IStream::operator bool() const
 {
-  return *myStream ? Standard_True : Standard_False;
+  return (*myStream && !myHasError) ? Standard_True : Standard_False;
 }
 
 //=======================================================================

--- a/src/ModelingData/TKBRep/BinTools/BinTools_IStream.cxx
+++ b/src/ModelingData/TKBRep/BinTools/BinTools_IStream.cxx
@@ -19,7 +19,8 @@
 BinTools_IStream::BinTools_IStream(Standard_IStream& theStream)
     : myStream(&theStream),
       myPosition(theStream.tellg()),
-      myLastType(BinTools_ObjectType_Unknown)
+      myLastType(BinTools_ObjectType_Unknown),
+      myHasError(Standard_False)
 {
 }
 
@@ -132,7 +133,7 @@ BinTools_IStream::operator bool() const
 BinTools_IStream& BinTools_IStream::operator>>(Standard_Real& theValue)
 {
   if (!myStream->read((char*)&theValue, sizeof(Standard_Real)))
-    throw Storage_StreamTypeMismatchError();
+    myHasError = Standard_True;
   myPosition += sizeof(Standard_Real);
 #if DO_INVERSE
   theValue = InverseReal(theValue);
@@ -147,7 +148,7 @@ BinTools_IStream& BinTools_IStream::operator>>(Standard_Real& theValue)
 BinTools_IStream& BinTools_IStream::operator>>(Standard_Integer& theValue)
 {
   if (!myStream->read((char*)&theValue, sizeof(Standard_Integer)))
-    throw Storage_StreamTypeMismatchError();
+    myHasError = Standard_True;
   myPosition += sizeof(Standard_Integer);
 #if DO_INVERSE
   theValue = InverseInt(theValue);
@@ -165,7 +166,7 @@ BinTools_IStream& BinTools_IStream::operator>>(gp_Pnt& theValue)
   for (int aCoord = 1; aCoord <= 3; aCoord++)
   {
     if (!myStream->read((char*)&aValue, sizeof(Standard_Real)))
-      throw Storage_StreamTypeMismatchError();
+      myHasError = Standard_True;
 #if DO_INVERSE
     aValue = InverseReal(aValue);
 #endif

--- a/src/ModelingData/TKBRep/BinTools/BinTools_IStream.cxx
+++ b/src/ModelingData/TKBRep/BinTools/BinTools_IStream.cxx
@@ -182,7 +182,8 @@ BinTools_IStream& BinTools_IStream::operator>>(gp_Pnt& theValue)
 //=======================================================================
 BinTools_IStream& BinTools_IStream::operator>>(Standard_Byte& theValue)
 {
-  myStream->read((char*)&theValue, sizeof(Standard_Byte));
+  if (!myStream->read((char*)&theValue, sizeof(Standard_Byte)))
+    myHasError = Standard_True;
   myPosition += sizeof(Standard_Byte);
   return *this;
 }
@@ -193,8 +194,13 @@ BinTools_IStream& BinTools_IStream::operator>>(Standard_Byte& theValue)
 //=======================================================================
 BinTools_IStream& BinTools_IStream::operator>>(Standard_ShortReal& theValue)
 {
-  myStream->read((char*)&theValue, sizeof(Standard_ShortReal));
+  if (!myStream->read((char*)&theValue, sizeof(Standard_ShortReal)))
+    myHasError = Standard_True;
   myPosition += sizeof(Standard_ShortReal);
+#if DO_INVERSE
+  if (!myHasError)
+    theValue = InverseShortReal(theValue);
+#endif
   return *this;
 }
 

--- a/src/ModelingData/TKBRep/BinTools/BinTools_IStream.hxx
+++ b/src/ModelingData/TKBRep/BinTools/BinTools_IStream.hxx
@@ -59,6 +59,12 @@ public:
   //! Returns false if stream reading is failed.
   Standard_EXPORT operator bool() const;
 
+  //! Returns the last error status.
+  Standard_Boolean HasError() const { return myHasError; }
+
+  //! Clears the error status.
+  void ClearError() { myHasError = Standard_False; }
+
   //! Reads real value from the stream.
   Standard_EXPORT Standard_Real ReadReal()
   {
@@ -136,6 +142,7 @@ private:
   Standard_IStream*   myStream;   ///< pointer to the stream
   uint64_t            myPosition; ///< equivalent to tellg returned value for fast access
   BinTools_ObjectType myLastType; ///< last type that was read
+  Standard_Boolean    myHasError; ///< indicates if an error occurred
 };
 
 #endif // _BinTools_IStream_HeaderFile

--- a/src/ModelingData/TKBRep/BinTools/BinTools_IStream.hxx
+++ b/src/ModelingData/TKBRep/BinTools/BinTools_IStream.hxx
@@ -60,9 +60,16 @@ public:
   Standard_EXPORT operator bool() const;
 
   //! Returns the last error status.
+  //! Use this method to check if any read operation has failed.
+  //! Reading operations (operator>> for Standard_Real, Standard_Integer, etc.)
+  //! set the error flag when the underlying stream read fails.
+  //! After detecting an error, callers should stop further read operations and handle the error appropriately.
   Standard_Boolean HasError() const { return myHasError; }
 
   //! Clears the error status.
+  //! Call this method before starting a new sequence of read operations
+  //! to reset the error state. This allows reusing the stream object
+  //! after recovering from a previous error condition.
   void ClearError() { myHasError = Standard_False; }
 
   //! Reads real value from the stream.

--- a/src/ModelingData/TKBRep/BinTools/BinTools_IStream.hxx
+++ b/src/ModelingData/TKBRep/BinTools/BinTools_IStream.hxx
@@ -63,7 +63,8 @@ public:
   //! Use this method to check if any read operation has failed.
   //! Reading operations (operator>> for Standard_Real, Standard_Integer, etc.)
   //! set the error flag when the underlying stream read fails.
-  //! After detecting an error, callers should stop further read operations and handle the error appropriately.
+  //! After detecting an error, callers should stop further read operations and handle the error
+  //! appropriately.
   Standard_Boolean HasError() const { return myHasError; }
 
   //! Clears the error status.


### PR DESCRIPTION
Replace exception-based error handling with error state management for Storage stream errors. This change eliminates throwing and catching of:
- Storage_StreamTypeMismatchError
- Storage_StreamExtCharParityError
- Storage_StreamWriteError
- Storage_StreamFormatError
- Storage_StreamReadError

Changes:
- Add error state management to Storage_BaseDriver with ErrorStatus(), ClearErrorStatus(), and SetErrorStatus() methods
- Update FSD_File, FSD_BinaryFile, and FSD_CmpFile to set error state instead of throwing exceptions
- Add error state management to BinTools_IStream
- Update BinTools static methods to rely on stream error state
- Replace try-catch blocks with error status checking
- Mark all affected exception classes as deprecated

The existing Storage_Error enum is used for error codes, maintaining compatibility with existing error handling patterns in OCCT.