### PR TITLE
Foundation Classes, CSLib - Migrate local variables from TColStd_Array1OfReal to math_Vector

### DIFF
--- a/src/FoundationClasses/TKMath/CSLib/CSLib.cxx
+++ b/src/FoundationClasses/TKMath/CSLib/CSLib.cxx
@@ -20,10 +20,10 @@
 #include <gp_Dir.hxx>
 #include <gp_Vec.hxx>
 #include <math_FunctionRoots.hxx>
+#include <math_Vector.hxx>
 #include <PLib.hxx>
 #include <Precision.hxx>
 #include <TColgp_Array2OfVec.hxx>
-#include <TColStd_Array1OfReal.hxx>
 #include <TColStd_Array2OfReal.hxx>
 
 void CSLib::Normal(
@@ -222,7 +222,7 @@ void CSLib::Normal(const Standard_Integer    MaxOrder,
     {
       gp_Vec Vk0;
       Vk0 = DerNUV(OrderU, OrderV);
-      TColStd_Array1OfReal Ratio(0, Order);
+      math_Vector Ratio(0, Order);
       // Calculate lambda i
       i                        = 0;
       Standard_Boolean definie = Standard_False;
@@ -311,7 +311,7 @@ void CSLib::Normal(const Standard_Integer    MaxOrder,
         {
           // ranking by increasing order of roots of SAPS in Sol0
 
-          TColStd_Array1OfReal Sol0(0, FindRoots.NbSolutions() + 1);
+          math_Vector Sol0(0, FindRoots.NbSolutions() + 1);
           Sol0(1)            = FindRoots.Value(1);
           Standard_Integer n = 1;
           while (n <= FindRoots.NbSolutions())

--- a/src/FoundationClasses/TKMath/CSLib/CSLib_Class2d.cxx
+++ b/src/FoundationClasses/TKMath/CSLib/CSLib_Class2d.cxx
@@ -55,20 +55,20 @@ void CSLib_Class2d::Init(const TCol_Containers2d& TP2d,
     N         = TP2d.Length();
     Tolu      = aTolu;
     Tolv      = aTolv;
-    MyPnts2dX = new TColStd_Array1OfReal(0, N);
-    MyPnts2dY = new TColStd_Array1OfReal(0, N);
+    MyPnts2dX = new math_Vector(0, N);
+    MyPnts2dY = new math_Vector(0, N);
     du        = umax - umin;
     dv        = vmax - vmin;
     //
     iLower = TP2d.Lower();
     for (i = 0; i < N; ++i)
     {
-      const gp_Pnt2d& aP2D      = TP2d(i + iLower);
-      MyPnts2dX->ChangeValue(i) = Transform2d(aP2D.X(), umin, du);
-      MyPnts2dY->ChangeValue(i) = Transform2d(aP2D.Y(), vmin, dv);
+      const gp_Pnt2d& aP2D = TP2d(i + iLower);
+      (*MyPnts2dX)(i)      = Transform2d(aP2D.X(), umin, du);
+      (*MyPnts2dY)(i)      = Transform2d(aP2D.Y(), vmin, dv);
     }
-    MyPnts2dX->ChangeLast() = MyPnts2dX->First();
-    MyPnts2dY->ChangeLast() = MyPnts2dY->First();
+    (*MyPnts2dX)(MyPnts2dX->Upper()) = (*MyPnts2dX)(MyPnts2dX->Lower());
+    (*MyPnts2dY)(MyPnts2dY->Upper()) = (*MyPnts2dY)(MyPnts2dY->Lower());
     //
     if (du > aPrc)
     {

--- a/src/FoundationClasses/TKMath/CSLib/CSLib_Class2d.hxx
+++ b/src/FoundationClasses/TKMath/CSLib/CSLib_Class2d.hxx
@@ -23,7 +23,7 @@
 
 #include <TColgp_Array1OfPnt2d.hxx>
 #include <NCollection_Handle.hxx>
-#include <TColStd_Array1OfReal.hxx>
+#include <math_Vector.hxx>
 #include <TColgp_SequenceOfPnt2d.hxx>
 
 class gp_Pnt2d;
@@ -92,14 +92,14 @@ private:
   //! Assign operator is forbidden
   const CSLib_Class2d& operator=(const CSLib_Class2d& Other) const;
 
-  NCollection_Handle<TColStd_Array1OfReal> MyPnts2dX, MyPnts2dY;
-  Standard_Real                            Tolu{};
-  Standard_Real                            Tolv{};
-  Standard_Integer                         N{};
-  Standard_Real                            Umin{};
-  Standard_Real                            Vmin{};
-  Standard_Real                            Umax{};
-  Standard_Real                            Vmax{};
+  NCollection_Handle<math_Vector> MyPnts2dX, MyPnts2dY;
+  Standard_Real                   Tolu{};
+  Standard_Real                   Tolv{};
+  Standard_Integer                N{};
+  Standard_Real                   Umin{};
+  Standard_Real                   Vmin{};
+  Standard_Real                   Umax{};
+  Standard_Real                   Vmax{};
 };
 
 #endif // _CSLib_Class2d_HeaderFile

--- a/src/FoundationClasses/TKMath/CSLib/CSLib_NormalPolyDef.cxx
+++ b/src/FoundationClasses/TKMath/CSLib/CSLib_NormalPolyDef.cxx
@@ -18,7 +18,7 @@
 #include <PLib.hxx>
 
 //=============================================================================
-CSLib_NormalPolyDef::CSLib_NormalPolyDef(const Standard_Integer k0, const TColStd_Array1OfReal& li)
+CSLib_NormalPolyDef::CSLib_NormalPolyDef(const Standard_Integer k0, const math_Vector& li)
     //=============================================================================
     : myTABli(0, k0)
 {

--- a/src/FoundationClasses/TKMath/CSLib/CSLib_NormalPolyDef.hxx
+++ b/src/FoundationClasses/TKMath/CSLib/CSLib_NormalPolyDef.hxx
@@ -21,8 +21,8 @@
 #include <Standard_DefineAlloc.hxx>
 #include <Standard_Handle.hxx>
 
-#include <TColStd_Array1OfReal.hxx>
 #include <math_FunctionWithDerivative.hxx>
+#include <math_Vector.hxx>
 #include <Standard_Boolean.hxx>
 
 class CSLib_NormalPolyDef : public math_FunctionWithDerivative
@@ -30,7 +30,7 @@ class CSLib_NormalPolyDef : public math_FunctionWithDerivative
 public:
   DEFINE_STANDARD_ALLOC
 
-  Standard_EXPORT CSLib_NormalPolyDef(const Standard_Integer k0, const TColStd_Array1OfReal& li);
+  Standard_EXPORT CSLib_NormalPolyDef(const Standard_Integer k0, const math_Vector& li);
 
   //! computes the value <F>of the function for the variable <X>.
   //! Returns True if the calculation were successfully done,
@@ -53,8 +53,8 @@ public:
 
 protected:
 private:
-  Standard_Integer     myK0;
-  TColStd_Array1OfReal myTABli;
+  Standard_Integer myK0;
+  math_Vector      myTABli;
 };
 
 #endif // _CSLib_NormalPolyDef_HeaderFile


### PR DESCRIPTION
This commit migrates local variables in CSLib.cxx from TColStd_Array1OfReal to math_Vector:
- Ratio array (local variable in Normal function)
- Sol0 array (local variable in Normal function)

Both variables are strictly local and not returned outside their scope, making the migration safe. Member variables in CSLib_Class2d and CSLib_NormalPolyDef remain unchanged as per requirements.

Updated includes:
- Added: math_Vector.hxx
- Removed: TColStd_Array1OfReal.hxx (no longer needed in this file)